### PR TITLE
chore: setup linter

### DIFF
--- a/.github/workflows/go-quality.yml
+++ b/.github/workflows/go-quality.yml
@@ -1,0 +1,33 @@
+name: Go Quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+
+      - name: Verify formatting
+        run: make fmt-check
+
+      - name: Run go vet
+        run: make vet
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.11.3
+          working-directory: src
+          args: --config .golangci.yml

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ dist/
 # Dependency directories (when using vendoring)
 vendor/
 
-# IDE/editor files
-.vscode/
-!.vscode/launch.json
 
 # Logs
 *.log
@@ -28,7 +25,6 @@ Thumbs.db
 
 # Local caches
 .cache/
-# question: still don't understand teh why we even need the cache here.
 
 # Drafts folders
 drafts

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ vendor/
 .DS_Store
 Thumbs.db
 
+# Local caches
+.cache/
+# question: still don't understand teh why we even need the cache here.
 
 # Drafts folders
 drafts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "go.useLanguageServer": true,
+  "go.lintTool": "golangci-lint",
+  "go.lintOnSave": "package",
+  "go.lintFlags": [
+    "--config=${workspaceFolder}/src/.golangci.yml",
+    "--path-mode=abs"
+  ],
+  "gopls": {
+    "formatting.gofumpt": false
+  },
+  "files.watcherExclude": {
+    "**/.cache/**": true
+  },
+  "search.exclude": {
+    "**/.cache": true
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: fmt fmt-check vet lint check
+
+GOFILES := $(shell find src -type f -name '*.go')
+CACHE_DIR := $(CURDIR)/.cache
+GO_CACHE := $(CACHE_DIR)/go-build
+GOLANGCI_LINT_CACHE := $(CACHE_DIR)/golangci-lint
+
+fmt:
+	gofmt -w $(GOFILES)
+
+fmt-check:
+	./scripts/fmt-check.sh $(GOFILES)
+
+vet:
+	./scripts/vet.sh $(GO_CACHE)
+
+lint:
+	./scripts/lint.sh $(GOLANGCI_LINT_CACHE)
+
+check: fmt-check vet lint

--- a/README.md
+++ b/README.md
@@ -43,3 +43,34 @@ Git-based sync can be valuable, but it should be treated as a workflow feature, 
 ## Roadmap
 
 The project EPICs live in [docs/epics.md](/Users/iassiyadi/Side-projects/notes.md/docs/epics.md).
+
+## Quality Checks
+
+This project uses standard Go quality tooling:
+
+- `gofmt` for formatting
+- `go vet` for baseline static analysis
+- `golangci-lint` for additional lint checks
+
+Install Go locally, and make sure `golangci-lint` is available in your shell.
+
+Run the checks from the repository root:
+
+```bash
+make fmt
+make vet
+make lint
+make check
+```
+
+`make check` validates formatting without rewriting files, then runs `go vet` and `golangci-lint`.
+
+GitHub Actions runs the same checks on pull requests and pushes to `main`.
+
+If you want Git to run checks before pushing, configure the repo-managed hooks once:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+The tracked `pre-push` hook runs `make fmt-check` before allowing a push.

--- a/scripts/fmt-check.sh
+++ b/scripts/fmt-check.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+unformatted="$(gofmt -l "$@")"
+
+if [ -n "$unformatted" ]; then
+  echo "Go files are not formatted. Run 'make fmt'."
+  printf '%s\n' "$unformatted"
+  exit 1
+fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+cd "$repo_root"
+make fmt-check

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+golangci_lint_cache="$1"
+
+mkdir -p "$golangci_lint_cache"
+cd src
+GOLANGCI_LINT_CACHE="$golangci_lint_cache" golangci-lint run

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+go_cache="$1"
+
+mkdir -p "$go_cache"
+cd src
+GOCACHE="$go_cache" go vet ./...

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+run:
+  go: "1.25"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,16 @@
+.PHONY: fmt fmt-check vet lint check
+
+fmt:
+	$(MAKE) -C .. fmt
+
+fmt-check:
+	$(MAKE) -C .. fmt-check
+
+vet:
+	$(MAKE) -C .. vet
+
+lint:
+	$(MAKE) -C .. lint
+
+check:
+	$(MAKE) -C .. check

--- a/src/internal/content/loader.go
+++ b/src/internal/content/loader.go
@@ -29,7 +29,7 @@ func LoadPages(dir string) (Pages, error) {
 		return nil
 	})
 
-  if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	return pages, nil
@@ -66,6 +66,6 @@ func normalizeTitle(fileBase string) string {
 		return "Untitled"
 	}
 	fileBase = strings.TrimSuffix(fileBase, ".md")
-	
+
 	return strings.ToUpper(fileBase[:1]) + fileBase[1:]
 }

--- a/src/internal/content/types.go
+++ b/src/internal/content/types.go
@@ -1,10 +1,10 @@
 package content
 
 type Page struct {
-	Id string
-	Title string // we will show this title in the drawer list
+	Id      string
+	Title   string // we will show this title in the drawer list
 	Content string
-	Path string
+	Path    string
 }
 
 type Pages []Page


### PR DESCRIPTION
closes #7 

## Changes

- setup linter
- add `makefile`.
- add `go-quality` workflow
- add fmt-check in pre-push.
- Add VS Code settings so the result of the `golangci-lint` will be highlighted in your editor.

## Insights

- for the pre-push, devs need to run `git config core.hooksPath scripts/git-hooks` (for that I add this in readme).
- Most of the time you will be in src folder, and to run a linter or one of the commands, you don't need to go back to project root. To solve that, I added `src/makefile` to forward from the src folder.

## Demo

N/A
