### PR TITLE
docs: clean up leftover Track/Manage references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,8 +21,8 @@
 ## Insights
 
 <!-- Tradeoffs, risks, or context a reviewer needs.
-     Flag any change to marker grammar, ID format, or status vocabulary —
-     existing `[lm-a1b2c3 open]` markers in already-scanned files must still parse. -->
+     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
+     vocabulary or how comments are detected. -->
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ In short:
 - editing still happens in the user's own editor: `leftmark` opens `$EDITOR` at the right file:line, it doesn't try to be one
 - the scan/report engine is kept independent of any single presentation layer, so the terminal app, and any front-end added later, are just clients built on top of it
 
-## Roadmap
-
-The project EPICs live in [docs/epics.md](/Users/iassiyadi/Side-projects/notes.md/docs/epics.md). This document predates the pivot above and needs a rewrite to match; treat it as historical until then.
-
 ## Quality checks
 
 This project uses standard Go quality tooling:


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar, ID format, or status vocabulary —
     existing `[lm-a1b2c3 open]` markers in already-scanned files must still parse. -->

## Demo

<!-- Terminal recording or screenshots for TUI-visible changes.
     CI can't verify these visually. N/A if not applicable. -->

## Related

<!-- Closes #123 -->
