### PR TITLE
feat(TUI): implement new UI

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -9,28 +9,36 @@ import (
 	"github.com/issam-assiyadi/leftmark/internal/ui/components/scrollview"
 )
 
+var categoryOrder = []domain.Kind{domain.KindTODO, domain.KindFIXME, domain.KindNOTE, domain.KindQUESTION}
+
 type App struct {
 	Service *application.Service
 
-	Items    []domain.Item
-	Selected int
+	Items           []domain.Item
+	itemsByCategory map[domain.Kind][]domain.Item
 
-	SidebarView string
-	Content     *scrollview.View
+	CategorySelected int
+	ItemSelected     int
+
+	CategoriesView string
+	Content        *scrollview.View
+
+	focused string
 
 	pendingEdit *domain.Item
 }
 
 func New(svc *application.Service) (*App, error) {
 	a := &App{
-		Service:     svc,
-		SidebarView: "sidebar",
+		Service:        svc,
+		CategoriesView: "categories",
 		Content: scrollview.New(scrollview.Config{
 			BaseName:       "content",
-			Title:          "Detail",
+			Title:          " [2] Items ",
 			ScrollbarWidth: 3,
 		}),
 	}
+	a.focused = a.CategoriesView
 
 	items, err := svc.Scan()
 	if err != nil {
@@ -41,21 +49,42 @@ func New(svc *application.Service) (*App, error) {
 	return a, nil
 }
 
-// setItems replaces the displayed items and clamps the current selection to
-// stay within bounds.
 func (a *App) setItems(items []domain.Item) {
 	a.Items = items
-	if a.Selected >= len(a.Items) {
-		a.Selected = len(a.Items) - 1
+
+	a.itemsByCategory = make(map[domain.Kind][]domain.Item, len(categoryOrder))
+	for _, item := range items {
+		a.itemsByCategory[item.Kind] = append(a.itemsByCategory[item.Kind], item)
 	}
-	if a.Selected < 0 {
-		a.Selected = 0
+
+	if a.CategorySelected < 0 {
+		a.CategorySelected = 0
+	}
+	if a.CategorySelected >= len(categoryOrder) {
+		a.CategorySelected = len(categoryOrder) - 1
+	}
+
+	n := len(a.currentCategoryItems())
+	if a.ItemSelected >= n {
+		a.ItemSelected = n - 1
+	}
+	if a.ItemSelected < 0 {
+		a.ItemSelected = 0
 	}
 }
 
+func (a *App) currentCategory() domain.Kind {
+	return categoryOrder[a.CategorySelected]
+}
+
+func (a *App) currentCategoryItems() []domain.Item {
+	return a.itemsByCategory[a.currentCategory()]
+}
+
 func (a *App) selectedItem() (domain.Item, bool) {
-	if a.Selected < 0 || a.Selected >= len(a.Items) {
+	items := a.currentCategoryItems()
+	if a.ItemSelected < 0 || a.ItemSelected >= len(items) {
 		return domain.Item{}, false
 	}
-	return a.Items[a.Selected], true
+	return items[a.ItemSelected], true
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/issam-assiyadi/leftmark"
+	"github.com/issam-assiyadi/leftmark/domain"
 )
 
 func newTestApp(t *testing.T, dir string) *App {
@@ -28,6 +29,9 @@ func TestNewScansOnStartup(t *testing.T) {
 	app := newTestApp(t, dir)
 	if len(app.Items) != 1 || app.Items[0].Text != "fix this" {
 		t.Fatalf("initial Items = %+v, want one TODO item", app.Items)
+	}
+	if got := app.itemsByCategory[domain.KindTODO]; len(got) != 1 || got[0].Text != "fix this" {
+		t.Fatalf("itemsByCategory[TODO] = %+v, want one TODO item", got)
 	}
 }
 
@@ -52,9 +56,34 @@ func TestRescanPicksUpChanges(t *testing.T) {
 	if len(app.Items) != 2 {
 		t.Fatalf("Items after rescan = %+v, want 2", app.Items)
 	}
+	if len(app.itemsByCategory[domain.KindTODO]) != 1 || len(app.itemsByCategory[domain.KindFIXME]) != 1 {
+		t.Fatalf("itemsByCategory after rescan = %+v, want one TODO and one FIXME", app.itemsByCategory)
+	}
 }
 
-func TestMoveUpDownClampToItemBounds(t *testing.T) {
+func TestCategoryMoveUpDownClampToCategoryBounds(t *testing.T) {
+	dir := t.TempDir()
+
+	app := newTestApp(t, dir)
+
+	if err := app.categoryMoveUp(nil, nil); err != nil {
+		t.Fatalf("categoryMoveUp: %v", err)
+	}
+	if app.CategorySelected != 0 {
+		t.Errorf("CategorySelected = %d after categoryMoveUp at top, want clamped to 0", app.CategorySelected)
+	}
+
+	for i := 0; i < len(categoryOrder)+2; i++ {
+		if err := app.categoryMoveDown(nil, nil); err != nil {
+			t.Fatalf("categoryMoveDown: %v", err)
+		}
+	}
+	if app.CategorySelected != len(categoryOrder)-1 {
+		t.Errorf("CategorySelected = %d after moving past the end, want clamped to %d", app.CategorySelected, len(categoryOrder)-1)
+	}
+}
+
+func TestItemMoveUpDownClampToItemBounds(t *testing.T) {
 	dir := t.TempDir()
 	mainGo := filepath.Join(dir, "main.go")
 	content := "// TODO: one\n// TODO: two\n// TODO: three\n"
@@ -63,23 +92,47 @@ func TestMoveUpDownClampToItemBounds(t *testing.T) {
 	}
 
 	app := newTestApp(t, dir)
-	if len(app.Items) != 3 {
-		t.Fatalf("Items = %+v, want 3", app.Items)
+	items := app.currentCategoryItems()
+	if len(items) != 3 {
+		t.Fatalf("currentCategoryItems = %+v, want 3", items)
 	}
 
-	if err := app.moveUp(nil, nil); err != nil {
-		t.Fatalf("moveUp: %v", err)
+	if err := app.itemMoveUp(nil, nil); err != nil {
+		t.Fatalf("itemMoveUp: %v", err)
 	}
-	if app.Selected != 0 {
-		t.Errorf("Selected = %d after moveUp at top, want clamped to 0", app.Selected)
+	if app.ItemSelected != 0 {
+		t.Errorf("ItemSelected = %d after itemMoveUp at top, want clamped to 0", app.ItemSelected)
 	}
 
 	for i := 0; i < 5; i++ {
-		if err := app.moveDown(nil, nil); err != nil {
-			t.Fatalf("moveDown: %v", err)
+		if err := app.itemMoveDown(nil, nil); err != nil {
+			t.Fatalf("itemMoveDown: %v", err)
 		}
 	}
-	if app.Selected != len(app.Items)-1 {
-		t.Errorf("Selected = %d after moving past the end, want clamped to %d", app.Selected, len(app.Items)-1)
+	if app.ItemSelected != len(items)-1 {
+		t.Errorf("ItemSelected = %d after moving past the end, want clamped to %d", app.ItemSelected, len(items)-1)
+	}
+}
+
+func TestCategoryMoveResetsItemSelection(t *testing.T) {
+	dir := t.TempDir()
+	content := "// TODO: one\n// TODO: two\n// FIXME: three\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	app := newTestApp(t, dir)
+	if err := app.itemMoveDown(nil, nil); err != nil {
+		t.Fatalf("itemMoveDown: %v", err)
+	}
+	if app.ItemSelected != 1 {
+		t.Fatalf("ItemSelected = %d before category change, want 1", app.ItemSelected)
+	}
+
+	if err := app.categoryMoveDown(nil, nil); err != nil {
+		t.Fatalf("categoryMoveDown: %v", err)
+	}
+	if app.ItemSelected != 0 {
+		t.Errorf("ItemSelected = %d after categoryMoveDown, want reset to 0", app.ItemSelected)
 	}
 }

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -19,7 +19,11 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 	}
 
 	contentLeft := x0 + 1
-	contentTop := y0 + 1
+	// gocui always insets a view's drawable area by 1 cell from its own
+	// rect, regardless of Frame (see View.setRune), so starting this rect at
+	// y0+1 would double that inset and push line 0 a row lower than the
+	// categories pane's line 0. Starting at y0 lines the two panes up.
+	contentTop := y0
 	contentRight := x1 - v.scrollbarWidth - 1
 	contentBottom := y1 - 1
 	scrollLeft := x1 - v.scrollbarWidth + 1

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -19,10 +19,6 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 	}
 
 	contentLeft := x0 + 1
-	// gocui always insets a view's drawable area by 1 cell from its own
-	// rect, regardless of Frame (see View.setRune), so starting this rect at
-	// y0+1 would double that inset and push line 0 a row lower than the
-	// categories pane's line 0. Starting at y0 lines the two panes up.
 	contentTop := y0
 	contentRight := x1 - v.scrollbarWidth - 1
 	contentBottom := y1 - 1

--- a/internal/ui/components/scrollview/render.go
+++ b/internal/ui/components/scrollview/render.go
@@ -6,6 +6,23 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
+func (v *View) SetTitle(g *gocui.Gui, title string) error {
+	if v == nil || g == nil {
+		return nil
+	}
+
+	wrapper, err := g.View(v.wrapperViewName)
+	if err != nil {
+		if err == gocui.ErrUnknownView {
+			return nil
+		}
+		return err
+	}
+
+	wrapper.Title = title
+	return nil
+}
+
 func (v *View) Render(g *gocui.Gui, renderFn func(*gocui.View, int) error) error {
 	if v == nil || g == nil {
 		return nil

--- a/internal/ui/components/scrollview/view.go
+++ b/internal/ui/components/scrollview/view.go
@@ -28,3 +28,9 @@ func New(cfg Config) *View {
 		scrollbarWidth:  scrollbarWidth,
 	}
 }
+
+func (v *View) WrapperName() string { return v.wrapperViewName }
+
+func (v *View) ContentViewName() string { return v.contentViewName }
+
+func (v *View) ScrollViewName() string { return v.scrollViewName }

--- a/internal/ui/editorhandoff.go
+++ b/internal/ui/editorhandoff.go
@@ -21,6 +21,10 @@ func (a *App) Run() error {
 			return err
 		}
 
+		g.Mouse = true
+		g.Highlight = true
+		g.SelFgColor = gocui.ColorCyan
+
 		g.SetManagerFunc(func(g *gocui.Gui) error {
 			if err := a.layout(g); err != nil {
 				return err
@@ -33,7 +37,15 @@ func (a *App) Run() error {
 			return err
 		}
 
-		if _, err := g.SetCurrentView(a.SidebarView); err != nil {
+		// Views only come into existence once the manager func runs, which
+		// gocui otherwise defers to the first MainLoop iteration. Run it here
+		// so the categories view already exists by the time we focus it —
+		// per-view keybindings never fire while g.currentView is nil.
+		if err := a.layout(g); err != nil {
+			g.Close()
+			return err
+		}
+		if _, err := g.SetCurrentView(a.focused); err != nil {
 			log.Println("unable to set initial view:", err)
 		}
 

--- a/internal/ui/editorhandoff.go
+++ b/internal/ui/editorhandoff.go
@@ -7,11 +7,6 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
-// errOpenEditor is returned by a keybinding handler to make gocui's
-// MainLoop return immediately, giving Run a clean point to close the Gui,
-// shell out to $EDITOR with full terminal control, and reopen a fresh Gui
-// afterward. jroimartin/gocui v0.5.0 has no suspend/resume API, so this
-// close/run/reopen loop is the mechanism, not a stopgap.
 var errOpenEditor = errors.New("ui: open in editor")
 
 func (a *App) Run() error {

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -7,26 +7,60 @@ import (
 )
 
 func (a *App) BindKeys(g *gocui.Gui) error {
-	bindings := []struct {
+	global := []struct {
 		key interface{}
 		fn  func(*gocui.Gui, *gocui.View) error
 	}{
 		{gocui.KeyCtrlC, quit},
 		{'q', quit},
-		{gocui.KeyArrowDown, a.moveDown},
-		{'j', a.moveDown},
-		{gocui.KeyArrowUp, a.moveUp},
-		{'k', a.moveUp},
-		{gocui.KeyEnter, a.openSelectedInEditor},
-		{'o', a.openSelectedInEditor},
 		{'r', a.rescan},
+		{'1', a.focusCategories},
+		{'2', a.focusItems},
 	}
-
-	for _, b := range bindings {
+	for _, b := range global {
 		if err := g.SetKeybinding("", b.key, gocui.ModNone, b.fn); err != nil {
 			return err
 		}
 	}
+
+	categoryKeys := []struct {
+		key interface{}
+		fn  func(*gocui.Gui, *gocui.View) error
+	}{
+		{gocui.KeyArrowDown, a.categoryMoveDown},
+		{'j', a.categoryMoveDown},
+		{gocui.KeyArrowUp, a.categoryMoveUp},
+		{'k', a.categoryMoveUp},
+		{gocui.MouseLeft, a.focusCategories},
+	}
+	for _, b := range categoryKeys {
+		if err := g.SetKeybinding(a.CategoriesView, b.key, gocui.ModNone, b.fn); err != nil {
+			return err
+		}
+	}
+
+	itemKeys := []struct {
+		key interface{}
+		fn  func(*gocui.Gui, *gocui.View) error
+	}{
+		{gocui.KeyArrowDown, a.itemMoveDown},
+		{'j', a.itemMoveDown},
+		{gocui.KeyArrowUp, a.itemMoveUp},
+		{'k', a.itemMoveUp},
+		{gocui.KeyEnter, a.openSelectedInEditor},
+		{'o', a.openSelectedInEditor},
+	}
+	for _, viewname := range []string{a.Content.WrapperName(), a.Content.ContentViewName(), a.Content.ScrollViewName()} {
+		if err := g.SetKeybinding(viewname, gocui.MouseLeft, gocui.ModNone, a.focusItems); err != nil {
+			return err
+		}
+	}
+	for _, b := range itemKeys {
+		if err := g.SetKeybinding(a.Content.WrapperName(), b.key, gocui.ModNone, b.fn); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -34,16 +68,44 @@ func quit(g *gocui.Gui, v *gocui.View) error {
 	return gocui.ErrQuit
 }
 
-func (a *App) moveDown(g *gocui.Gui, v *gocui.View) error {
-	if a.Selected < len(a.Items)-1 {
-		a.Selected++
+func (a *App) focusCategories(g *gocui.Gui, v *gocui.View) error {
+	a.focused = a.CategoriesView
+	_, err := g.SetCurrentView(a.focused)
+	return err
+}
+
+func (a *App) focusItems(g *gocui.Gui, v *gocui.View) error {
+	a.focused = a.Content.WrapperName()
+	_, err := g.SetCurrentView(a.focused)
+	return err
+}
+
+func (a *App) categoryMoveDown(g *gocui.Gui, v *gocui.View) error {
+	if a.CategorySelected < len(categoryOrder)-1 {
+		a.CategorySelected++
+		a.ItemSelected = 0
 	}
 	return nil
 }
 
-func (a *App) moveUp(g *gocui.Gui, v *gocui.View) error {
-	if a.Selected > 0 {
-		a.Selected--
+func (a *App) categoryMoveUp(g *gocui.Gui, v *gocui.View) error {
+	if a.CategorySelected > 0 {
+		a.CategorySelected--
+		a.ItemSelected = 0
+	}
+	return nil
+}
+
+func (a *App) itemMoveDown(g *gocui.Gui, v *gocui.View) error {
+	if a.ItemSelected < len(a.currentCategoryItems())-1 {
+		a.ItemSelected++
+	}
+	return nil
+}
+
+func (a *App) itemMoveUp(g *gocui.Gui, v *gocui.View) error {
+	if a.ItemSelected > 0 {
+		a.ItemSelected--
 	}
 	return nil
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -22,15 +22,17 @@ func (a *App) layout(g *gocui.Gui) error {
 		sidebarWidth = 2
 	}
 
-	sv, err := g.SetView(a.SidebarView, 0, 0, sidebarWidth-1, maxY-1)
+	sv, err := g.SetView(a.CategoriesView, 0, 0, sidebarWidth-1, maxY-1)
 	if err != nil && err != gocui.ErrUnknownView {
 		return err
 	}
 	if err == gocui.ErrUnknownView {
-		sv.Title = "Items"
-		sv.Highlight = true
-		sv.SelBgColor = gocui.ColorGreen
-		sv.Wrap = true
+		sv.Title = " [1] Categories "
+		// Rows are hand-formatted to exactly fill the view's width (see
+		// formatCategoryRow), so wrapping is unwanted here: gocui treats an
+		// exactly-full line as wrapping, inserting a blank continuation line
+		// before the row's own "\n".
+		sv.Wrap = false
 	}
 
 	contentLeft := sidebarWidth

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -28,10 +28,6 @@ func (a *App) layout(g *gocui.Gui) error {
 	}
 	if err == gocui.ErrUnknownView {
 		sv.Title = " [1] Categories "
-		// Rows are hand-formatted to exactly fill the view's width (see
-		// formatCategoryRow), so wrapping is unwanted here: gocui treats an
-		// exactly-full line as wrapping, inserting a blank continuation line
-		// before the row's own "\n".
 		sv.Wrap = false
 	}
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -17,7 +17,7 @@ func (a *App) Render(g *gocui.Gui) error {
 	cv.Clear()
 
 	cvWidth, _ := cv.Size()
-	rowWidth := cvWidth - len("  ") // prefix is always 2 columns, even when unselected
+	rowWidth := cvWidth - len("  ")
 	for i, kind := range categoryOrder {
 		prefix := "  "
 		if i == a.CategorySelected {
@@ -52,20 +52,14 @@ func renderItemRow(item domain.Item) string {
 	return fmt.Sprintf("%s:%d %s", item.File, item.Line, item.Text)
 }
 
-// categoryMetaRightPad keeps the item count from sitting flush against the
-// view's right border.
 const categoryMetaRightPad = 1
 
-// formatCategoryRow lays out a category name against its item count so the
-// count always lands near the row's right edge, truncating the name with
-// "..." rather than letting a long name push the count off-screen or wrap it
-// onto its own line.
 func formatCategoryRow(width int, kind domain.Kind, count int) string {
 	meta := fmt.Sprintf("%d", count)
 	title := string(kind)
 
 	metaWidth := len(meta) + categoryMetaRightPad
-	avail := width - metaWidth - 1 // 1 column gap between title and meta
+	avail := width - metaWidth - 1
 	if avail < 0 {
 		avail = 0
 	}

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jroimartin/gocui"
 
@@ -9,37 +10,76 @@ import (
 )
 
 func (a *App) Render(g *gocui.Gui) error {
-	sv, err := g.View(a.SidebarView)
+	cv, err := g.View(a.CategoriesView)
 	if err != nil {
 		return err
 	}
-	sv.Clear()
+	cv.Clear()
 
-	if len(a.Items) == 0 {
-		_, _ = fmt.Fprintln(sv, "No items")
-	}
-	for i, item := range a.Items {
+	cvWidth, _ := cv.Size()
+	rowWidth := cvWidth - len("  ") // prefix is always 2 columns, even when unselected
+	for i, kind := range categoryOrder {
 		prefix := "  "
-		if i == a.Selected {
+		if i == a.CategorySelected {
 			prefix = "> "
 		}
-		_, _ = fmt.Fprintln(sv, prefix+renderRow(item))
+		count := len(a.itemsByCategory[kind])
+		_, _ = fmt.Fprintln(cv, prefix+formatCategoryRow(rowWidth, kind, count))
+	}
+
+	items := a.currentCategoryItems()
+	if err := a.Content.SetTitle(g, fmt.Sprintf(" [2] Items - %s ", a.currentCategory())); err != nil {
+		return err
 	}
 
 	return a.Content.Render(g, func(v *gocui.View, contentWidth int) error {
-		item, ok := a.selectedItem()
-		if !ok {
-			_, _ = fmt.Fprintln(v, "No item selected")
+		if len(items) == 0 {
+			_, _ = fmt.Fprintln(v, "No items in this category")
 			return nil
 		}
-
-		_, _ = fmt.Fprintf(v, "%s\n", item.Kind)
-		_, _ = fmt.Fprintf(v, "%s:%d\n\n", item.File, item.Line)
-		_, _ = fmt.Fprintln(v, item.Text)
+		for i, item := range items {
+			prefix := "  "
+			if i == a.ItemSelected {
+				prefix = "> "
+			}
+			_, _ = fmt.Fprintln(v, prefix+renderItemRow(item))
+		}
 		return nil
 	})
 }
 
-func renderRow(item domain.Item) string {
-	return fmt.Sprintf("%-9s %s:%d %s", item.Kind, item.File, item.Line, item.Text)
+func renderItemRow(item domain.Item) string {
+	return fmt.Sprintf("%s:%d %s", item.File, item.Line, item.Text)
+}
+
+// categoryMetaRightPad keeps the item count from sitting flush against the
+// view's right border.
+const categoryMetaRightPad = 1
+
+// formatCategoryRow lays out a category name against its item count so the
+// count always lands near the row's right edge, truncating the name with
+// "..." rather than letting a long name push the count off-screen or wrap it
+// onto its own line.
+func formatCategoryRow(width int, kind domain.Kind, count int) string {
+	meta := fmt.Sprintf("%d", count)
+	title := string(kind)
+
+	metaWidth := len(meta) + categoryMetaRightPad
+	avail := width - metaWidth - 1 // 1 column gap between title and meta
+	if avail < 0 {
+		avail = 0
+	}
+	if len(title) > avail {
+		if avail <= 3 {
+			title = title[:avail]
+		} else {
+			title = title[:avail-3] + "..."
+		}
+	}
+
+	gap := width - len(title) - metaWidth
+	if gap < 1 {
+		gap = 1
+	}
+	return title + strings.Repeat(" ", gap) + meta + strings.Repeat(" ", categoryMetaRightPad)
 }

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/issam-assiyadi/leftmark/domain"
+)
+
+func TestFormatCategoryRow(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		kind  domain.Kind
+		count int
+		want  string
+	}{
+		{"fits with room to spare", 20, domain.KindTODO, 3, "TODO              3 "},
+		{"exact fit, no truncation", 9, domain.KindTODO, 3, "TODO   3 "},
+		{"truncated with ellipsis", 12, domain.Kind("TO CHALLENGE"), 2, "TO CHA... 2 "},
+		{"too narrow for ellipsis", 6, domain.Kind("TO CHALLENGE"), 2, "TO  2 "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCategoryRow(tt.width, tt.kind, tt.count)
+			if got != tt.want {
+				t.Errorf("formatCategoryRow(%d, %q, %d) = %q, want %q", tt.width, tt.kind, tt.count, got, tt.want)
+			}
+			if len(got) != tt.width {
+				t.Errorf("formatCategoryRow(%d, %q, %d) length = %d, want %d", tt.width, tt.kind, tt.count, len(got), tt.width)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- update the TUI layout (split it to categories and items)
- implement the navigation system
     - navigation using the keybindings
     - mouse focus 

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo

<img width="978" height="344" alt="image" src="https://github.com/user-attachments/assets/6d2cbf1e-92aa-4b14-b66d-e9678e750dea" />


## Related

Closes #22 
Closes #12 
