### PR TITLE
fix(UI): fix the scroll bar view

### DIFF
--- a/internal/ui/components/scrollview/render.go
+++ b/internal/ui/components/scrollview/render.go
@@ -78,10 +78,11 @@ func (v *View) renderScrollbar(contentView, scrollView *gocui.View) error {
 		}
 	}
 
-	thumbHeight := scrollHeight
-	if lines > height {
-		thumbHeight = max(1, scrollHeight*height/lines)
+	if lines <= height {
+		return nil
 	}
+
+	thumbHeight := max(1, scrollHeight*height/lines)
 	if thumbHeight > scrollHeight {
 		thumbHeight = scrollHeight
 	}


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo

no content case:
<img width="974" height="589" alt="image" src="https://github.com/user-attachments/assets/77a69a2b-564e-43d4-9f1c-7256511374cd" />

content fit in the view
<img width="969" height="606" alt="image" src="https://github.com/user-attachments/assets/a9ade8ab-79fa-4e90-a262-4aec1e31c582" />


when the conetnt doesn't fit the view

<img width="960" height="577" alt="image" src="https://github.com/user-attachments/assets/751f87a5-0573-43e8-b796-91e1f0e6db37" />


## Related

Closes #36 
