### PR TITLE
fix(ui): keep selected item in view when scrolling

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -20,8 +20,8 @@ type App struct {
 	CategorySelected int
 	ItemSelected     int
 
-	CategoriesView string
-	Content        *scrollview.View
+	Categories *scrollview.View
+	Content    *scrollview.View
 
 	focused string
 
@@ -30,15 +30,19 @@ type App struct {
 
 func New(svc *application.Service) (*App, error) {
 	a := &App{
-		Service:        svc,
-		CategoriesView: "categories",
+		Service: svc,
+		Categories: scrollview.New(scrollview.Config{
+			BaseName:      "categories",
+			Title:         " [1] Categories ",
+			HideScrollbar: true,
+		}),
 		Content: scrollview.New(scrollview.Config{
 			BaseName:       "content",
 			Title:          " [2] Items ",
 			ScrollbarWidth: 3,
 		}),
 	}
-	a.focused = a.CategoriesView
+	a.focused = a.Categories.WrapperName()
 
 	items, err := svc.Scan()
 	if err != nil {

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -20,17 +20,14 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 
 	contentLeft := x0 + 1
 	contentTop := y0
-	contentRight := x1 - v.scrollbarWidth - 1
 	contentBottom := y1 - 1
-	scrollLeft := x1 - v.scrollbarWidth + 1
-	scrollTop := y0
-	scrollRight := x1
-	scrollBottom := y1
+
+	contentRight := x1 - 1
+	if !v.hideScrollbar {
+		contentRight = x1 - v.scrollbarWidth - 1
+	}
 
 	if contentLeft >= contentRight || contentTop >= contentBottom {
-		return nil
-	}
-	if scrollLeft >= scrollRight || scrollTop >= scrollBottom {
 		return nil
 	}
 
@@ -42,6 +39,19 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 		contentView.Frame = false
 		contentView.Wrap = false
 		contentView.Autoscroll = false
+	}
+
+	if v.hideScrollbar {
+		return nil
+	}
+
+	scrollLeft := x1 - v.scrollbarWidth + 1
+	scrollTop := y0
+	scrollRight := x1
+	scrollBottom := y1
+
+	if scrollLeft >= scrollRight || scrollTop >= scrollBottom {
+		return nil
 	}
 
 	scrollView, err := g.SetView(v.scrollViewName, scrollLeft, scrollTop, scrollRight, scrollBottom)

--- a/internal/ui/components/scrollview/render.go
+++ b/internal/ui/components/scrollview/render.go
@@ -34,15 +34,17 @@ func (v *View) Render(g *gocui.Gui, focus int, renderFn func(*gocui.View, int) e
 	}
 
 	scrollView, err := v.scrollView(g)
-	if err != nil || scrollView == nil {
+	if err != nil {
 		return err
 	}
 
 	contentView.Clear()
-	scrollView.Clear()
 
-	if err := scrollView.SetOrigin(0, 0); err != nil {
-		return err
+	if scrollView != nil {
+		scrollView.Clear()
+		if err := scrollView.SetOrigin(0, 0); err != nil {
+			return err
+		}
 	}
 
 	if renderFn != nil {
@@ -53,6 +55,10 @@ func (v *View) Render(g *gocui.Gui, focus int, renderFn func(*gocui.View, int) e
 
 	if err := v.ensureVisible(contentView, focus); err != nil {
 		return err
+	}
+
+	if scrollView == nil {
+		return nil
 	}
 
 	return v.renderScrollbar(contentView, scrollView)

--- a/internal/ui/components/scrollview/render.go
+++ b/internal/ui/components/scrollview/render.go
@@ -23,7 +23,7 @@ func (v *View) SetTitle(g *gocui.Gui, title string) error {
 	return nil
 }
 
-func (v *View) Render(g *gocui.Gui, renderFn func(*gocui.View, int) error) error {
+func (v *View) Render(g *gocui.Gui, focus int, renderFn func(*gocui.View, int) error) error {
 	if v == nil || g == nil {
 		return nil
 	}
@@ -51,7 +51,43 @@ func (v *View) Render(g *gocui.Gui, renderFn func(*gocui.View, int) error) error
 		}
 	}
 
+	if err := v.ensureVisible(contentView, focus); err != nil {
+		return err
+	}
+
 	return v.renderScrollbar(contentView, scrollView)
+}
+
+func (v *View) ensureVisible(contentView *gocui.View, focus int) error {
+	if contentView == nil || focus < 0 {
+		return nil
+	}
+
+	_, height := contentView.Size()
+	if height <= 0 {
+		return nil
+	}
+
+	originX, originY := contentView.Origin()
+	newOriginY := originY
+	if focus < newOriginY {
+		newOriginY = focus
+	} else if focus >= newOriginY+height {
+		newOriginY = focus - height + 1
+	}
+
+	if maxOrigin := v.maxOrigin(contentView); newOriginY > maxOrigin {
+		newOriginY = maxOrigin
+	}
+	if newOriginY < 0 {
+		newOriginY = 0
+	}
+
+	if newOriginY == originY {
+		return nil
+	}
+
+	return contentView.SetOrigin(originX, newOriginY)
 }
 
 func (v *View) renderScrollbar(contentView, scrollView *gocui.View) error {

--- a/internal/ui/components/scrollview/view.go
+++ b/internal/ui/components/scrollview/view.go
@@ -4,6 +4,9 @@ type Config struct {
 	BaseName       string
 	Title          string
 	ScrollbarWidth int
+	// HideScrollbar makes the view scrollable via keyboard/selection
+	// without ever drawing a scrollbar column.
+	HideScrollbar bool
 }
 
 type View struct {
@@ -12,12 +15,16 @@ type View struct {
 	scrollViewName  string
 	title           string
 	scrollbarWidth  int
+	hideScrollbar   bool
 }
 
 func New(cfg Config) *View {
 	scrollbarWidth := cfg.ScrollbarWidth
-	if scrollbarWidth < 2 {
+	if !cfg.HideScrollbar && scrollbarWidth < 2 {
 		scrollbarWidth = 2
+	}
+	if cfg.HideScrollbar {
+		scrollbarWidth = 0
 	}
 
 	return &View{
@@ -26,6 +33,7 @@ func New(cfg Config) *View {
 		scrollViewName:  cfg.BaseName + "-scroll",
 		title:           cfg.Title,
 		scrollbarWidth:  scrollbarWidth,
+		hideScrollbar:   cfg.HideScrollbar,
 	}
 }
 

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -23,6 +23,12 @@ func (a *App) BindKeys(g *gocui.Gui) error {
 		}
 	}
 
+	for _, viewname := range []string{a.Categories.WrapperName(), a.Categories.ContentViewName()} {
+		if err := g.SetKeybinding(viewname, gocui.MouseLeft, gocui.ModNone, a.focusCategories); err != nil {
+			return err
+		}
+	}
+
 	categoryKeys := []struct {
 		key interface{}
 		fn  func(*gocui.Gui, *gocui.View) error
@@ -31,10 +37,9 @@ func (a *App) BindKeys(g *gocui.Gui) error {
 		{'j', a.categoryMoveDown},
 		{gocui.KeyArrowUp, a.categoryMoveUp},
 		{'k', a.categoryMoveUp},
-		{gocui.MouseLeft, a.focusCategories},
 	}
 	for _, b := range categoryKeys {
-		if err := g.SetKeybinding(a.CategoriesView, b.key, gocui.ModNone, b.fn); err != nil {
+		if err := g.SetKeybinding(a.Categories.WrapperName(), b.key, gocui.ModNone, b.fn); err != nil {
 			return err
 		}
 	}
@@ -69,7 +74,7 @@ func quit(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (a *App) focusCategories(g *gocui.Gui, v *gocui.View) error {
-	a.focused = a.CategoriesView
+	a.focused = a.Categories.WrapperName()
 	_, err := g.SetCurrentView(a.focused)
 	return err
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -22,13 +22,8 @@ func (a *App) layout(g *gocui.Gui) error {
 		sidebarWidth = 2
 	}
 
-	sv, err := g.SetView(a.CategoriesView, 0, 0, sidebarWidth-1, maxY-1)
-	if err != nil && err != gocui.ErrUnknownView {
+	if err := a.Categories.Layout(g, 0, 0, sidebarWidth-1, maxY-1); err != nil {
 		return err
-	}
-	if err == gocui.ErrUnknownView {
-		sv.Title = " [1] Categories "
-		sv.Wrap = false
 	}
 
 	contentLeft := sidebarWidth

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -10,21 +10,19 @@ import (
 )
 
 func (a *App) Render(g *gocui.Gui) error {
-	cv, err := g.View(a.CategoriesView)
-	if err != nil {
-		return err
-	}
-	cv.Clear()
-
-	cvWidth, _ := cv.Size()
-	rowWidth := cvWidth - len("  ")
-	for i, kind := range categoryOrder {
-		prefix := "  "
-		if i == a.CategorySelected {
-			prefix = "> "
+	if err := a.Categories.Render(g, a.CategorySelected, func(v *gocui.View, contentWidth int) error {
+		rowWidth := contentWidth - len("  ")
+		for i, kind := range categoryOrder {
+			prefix := "  "
+			if i == a.CategorySelected {
+				prefix = "> "
+			}
+			count := len(a.itemsByCategory[kind])
+			_, _ = fmt.Fprintln(v, prefix+formatCategoryRow(rowWidth, kind, count))
 		}
-		count := len(a.itemsByCategory[kind])
-		_, _ = fmt.Fprintln(cv, prefix+formatCategoryRow(rowWidth, kind, count))
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	items := a.currentCategoryItems()

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -32,7 +32,12 @@ func (a *App) Render(g *gocui.Gui) error {
 		return err
 	}
 
-	return a.Content.Render(g, func(v *gocui.View, contentWidth int) error {
+	focus := a.ItemSelected
+	if len(items) == 0 {
+		focus = -1
+	}
+
+	return a.Content.Render(g, focus, func(v *gocui.View, contentWidth int) error {
 		if len(items) == 0 {
 			_, _ = fmt.Fprintln(v, "No items in this category")
 			return nil


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo

<!-- Terminal recording or screenshots for TUI-visible changes.
     CI can't verify these visually. N/A if not applicable. -->

## Related

Closes #47 
