### PR TITLE
feat(ui): highlight selection and focused titles with pane accent color

### DIFF
--- a/internal/ui/components/scrollview/border.go
+++ b/internal/ui/components/scrollview/border.go
@@ -20,10 +20,7 @@ const (
 func drawRoundedFrame(g *gocui.Gui, v *gocui.View, x0, y0, x1, y1 int, title string) error {
 	maxX, maxY := g.Size()
 
-	fgColor, bgColor := g.FgColor, g.BgColor
-	if g.Highlight && g.CurrentView() == v {
-		fgColor, bgColor = g.SelFgColor, g.SelBgColor
-	}
+	fgColor, bgColor := frameColors(g, v)
 
 	for x := x0 + 1; x < x1 && x < maxX; x++ {
 		if x < 0 {
@@ -88,4 +85,15 @@ func drawRoundedFrame(g *gocui.Gui, v *gocui.View, x0, y0, x1, y1 int, title str
 	}
 
 	return nil
+}
+
+// frameColors returns the color pair a bordered view (or anything
+// visually tied to it, such as its scrollbar) should be drawn with:
+// the selection colors while it holds focus, the default frame
+// colors otherwise.
+func frameColors(g *gocui.Gui, v *gocui.View) (gocui.Attribute, gocui.Attribute) {
+	if g.Highlight && g.CurrentView() == v {
+		return g.SelFgColor, g.SelBgColor
+	}
+	return g.FgColor, g.BgColor
 }

--- a/internal/ui/components/scrollview/border.go
+++ b/internal/ui/components/scrollview/border.go
@@ -1,0 +1,91 @@
+package scrollview
+
+import "github.com/jroimartin/gocui"
+
+const (
+	borderHorizontal  = '─'
+	borderVertical    = '│'
+	cornerTopLeft     = '╭'
+	cornerTopRight    = '╮'
+	cornerBottomLeft  = '╰'
+	cornerBottomRight = '╯'
+)
+
+// drawRoundedFrame draws a border with rounded corners around
+// (x0,y0)-(x1,y1). gocui hard-codes square corners for any view with
+// Frame set to true, so views that want rounded corners keep Frame
+// false and get their border drawn here instead, replicating gocui's
+// own edge/corner/title logic (see gocui's drawFrameEdges,
+// drawFrameCorners and drawTitle) with rounded corner glyphs.
+func drawRoundedFrame(g *gocui.Gui, v *gocui.View, x0, y0, x1, y1 int, title string) error {
+	maxX, maxY := g.Size()
+
+	fgColor, bgColor := g.FgColor, g.BgColor
+	if g.Highlight && g.CurrentView() == v {
+		fgColor, bgColor = g.SelFgColor, g.SelBgColor
+	}
+
+	for x := x0 + 1; x < x1 && x < maxX; x++ {
+		if x < 0 {
+			continue
+		}
+		if y0 > -1 && y0 < maxY {
+			if err := g.SetRune(x, y0, borderHorizontal, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+		if y1 > -1 && y1 < maxY {
+			if err := g.SetRune(x, y1, borderHorizontal, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+	}
+	for y := y0 + 1; y < y1 && y < maxY; y++ {
+		if y < 0 {
+			continue
+		}
+		if x0 > -1 && x0 < maxX {
+			if err := g.SetRune(x0, y, borderVertical, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+		if x1 > -1 && x1 < maxX {
+			if err := g.SetRune(x1, y, borderVertical, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+	}
+
+	corners := []struct {
+		x, y int
+		ch   rune
+	}{
+		{x0, y0, cornerTopLeft},
+		{x1, y0, cornerTopRight},
+		{x0, y1, cornerBottomLeft},
+		{x1, y1, cornerBottomRight},
+	}
+	for _, c := range corners {
+		if c.x >= 0 && c.y >= 0 && c.x < maxX && c.y < maxY {
+			if err := g.SetRune(c.x, c.y, c.ch, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+	}
+
+	if title != "" && y0 >= 0 && y0 < maxY {
+		for i, ch := range title {
+			x := x0 + i + 2
+			if x < 0 {
+				continue
+			} else if x > x1-2 || x >= maxX {
+				break
+			}
+			if err := g.SetRune(x, y0, ch, fgColor, bgColor); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/ui/components/scrollview/border.go
+++ b/internal/ui/components/scrollview/border.go
@@ -71,6 +71,10 @@ func drawRoundedFrame(g *gocui.Gui, v *gocui.View, x0, y0, x1, y1 int, title str
 	}
 
 	if title != "" && y0 >= 0 && y0 < maxY {
+		titleFgColor := fgColor
+		if g.Highlight && g.CurrentView() == v {
+			titleFgColor |= gocui.AttrBold
+		}
 		for i, ch := range title {
 			x := x0 + i + 2
 			if x < 0 {
@@ -78,7 +82,7 @@ func drawRoundedFrame(g *gocui.Gui, v *gocui.View, x0, y0, x1, y1 int, title str
 			} else if x > x1-2 || x >= maxX {
 				break
 			}
-			if err := g.SetRune(x, y0, ch, fgColor, bgColor); err != nil {
+			if err := g.SetRune(x, y0, ch, titleFgColor, bgColor); err != nil {
 				return err
 			}
 		}
@@ -96,4 +100,20 @@ func frameColors(g *gocui.Gui, v *gocui.View) (gocui.Attribute, gocui.Attribute)
 		return g.SelFgColor, g.SelBgColor
 	}
 	return g.FgColor, g.BgColor
+}
+
+// FocusFgColor returns the foreground color this pane's border and
+// scrollbar are currently drawn with, so other elements tied to this
+// pane (such as its selected row) can share the same focus/unfocused
+// accent instead of hardcoding their own colors.
+func (v *View) FocusFgColor(g *gocui.Gui) gocui.Attribute {
+	if v == nil || g == nil {
+		return gocui.ColorDefault
+	}
+	wrapper, err := g.View(v.wrapperViewName)
+	if err != nil {
+		return gocui.ColorDefault
+	}
+	fgColor, _ := frameColors(g, wrapper)
+	return fgColor
 }

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -15,7 +15,10 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 		return err
 	}
 	if err == gocui.ErrUnknownView {
-		wrapper.Title = v.title
+		wrapper.Frame = false
+	}
+	if err := drawRoundedFrame(g, wrapper, x0, y0, x1, y1, v.title); err != nil {
+		return err
 	}
 
 	contentLeft := x0 + 1

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -16,8 +16,9 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 	}
 	if err == gocui.ErrUnknownView {
 		wrapper.Frame = false
+		wrapper.Title = v.title
 	}
-	if err := drawRoundedFrame(g, wrapper, x0, y0, x1, y1, v.title); err != nil {
+	if err := drawRoundedFrame(g, wrapper, x0, y0, x1, y1, wrapper.Title); err != nil {
 		return err
 	}
 

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -64,9 +64,9 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 	if err == gocui.ErrUnknownView {
 		scrollView.Frame = false
 		scrollView.Wrap = false
-		scrollView.FgColor = gocui.ColorWhite
 		scrollView.BgColor = gocui.ColorDefault
 	}
+	scrollView.FgColor, _ = frameColors(g, wrapper)
 
 	return nil
 }

--- a/internal/ui/editorhandoff.go
+++ b/internal/ui/editorhandoff.go
@@ -21,10 +21,14 @@ func (a *App) Run() error {
 		g.SelFgColor = gocui.ColorCyan
 
 		g.SetManagerFunc(func(g *gocui.Gui) error {
-			if err := a.layout(g); err != nil {
+			// Render before layout: Render() is what updates each pane's
+			// title (e.g. the "- <category>" suffix), and layout draws
+			// the border/title using the view's *current* title. Drawing
+			// first would render last frame's title, one step behind.
+			if err := a.Render(g); err != nil {
 				return err
 			}
-			return a.Render(g)
+			return a.layout(g)
 		})
 
 		if err := a.BindKeys(g); err != nil {

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -9,16 +9,37 @@ import (
 	"github.com/issam-assiyadi/leftmark/domain"
 )
 
+const rowStyleReset = "\x1b[0m"
+
+// selectedRowStyle marks a row as selected with bold + reverse video,
+// tinted with fgColor beforehand — the same accent frameColors gives
+// this pane's border/scrollbar, so the highlight reads as "active"
+// (accent-tinted) or "inactive" (theme-default) the same way they do.
+// Reverse video does the contrast work, so the highlight still adapts
+// to dark, light, or transparent terminal themes rather than assuming
+// one. fgColor must come before bold/reverse: gocui's escape parser
+// assigns fg/bg colors outright (rather than OR-ing them in), so
+// setting it after bold/reverse would wipe those bits back out.
+func selectedRowStyle(fgColor gocui.Attribute) string {
+	code := 39
+	if fgColor != gocui.ColorDefault {
+		code = 30 + int(fgColor) - 1
+	}
+	return fmt.Sprintf("\x1b[%d;1;7m", code)
+}
+
 func (a *App) Render(g *gocui.Gui) error {
+	categoryStyle := selectedRowStyle(a.Categories.FocusFgColor(g))
 	if err := a.Categories.Render(g, a.CategorySelected, func(v *gocui.View, contentWidth int) error {
 		rowWidth := contentWidth - len("  ")
 		for i, kind := range categoryOrder {
-			prefix := "  "
-			if i == a.CategorySelected {
-				prefix = "> "
-			}
 			count := len(a.itemsByCategory[kind])
-			_, _ = fmt.Fprintln(v, prefix+formatCategoryRow(rowWidth, kind, count))
+			row := "  " + formatCategoryRow(rowWidth, kind, count)
+			if i == a.CategorySelected {
+				_, _ = fmt.Fprintf(v, "%s%s%s\n", categoryStyle, row, rowStyleReset)
+			} else {
+				_, _ = fmt.Fprintln(v, row)
+			}
 		}
 		return nil
 	}); err != nil {
@@ -35,17 +56,22 @@ func (a *App) Render(g *gocui.Gui) error {
 		focus = -1
 	}
 
+	itemStyle := selectedRowStyle(a.Content.FocusFgColor(g))
 	return a.Content.Render(g, focus, func(v *gocui.View, contentWidth int) error {
 		if len(items) == 0 {
 			_, _ = fmt.Fprintln(v, "No items in this category")
 			return nil
 		}
 		for i, item := range items {
-			prefix := "  "
+			line := "  " + renderItemRow(item)
 			if i == a.ItemSelected {
-				prefix = "> "
+				if pad := contentWidth - len(line); pad > 0 {
+					line += strings.Repeat(" ", pad)
+				}
+				_, _ = fmt.Fprintf(v, "%s%s%s\n", itemStyle, line, rowStyleReset)
+			} else {
+				_, _ = fmt.Fprintln(v, line)
 			}
-			_, _ = fmt.Fprintln(v, prefix+renderItemRow(item))
 		}
 		return nil
 	})


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo
vscode
<img width="967" height="499" alt="image" src="https://github.com/user-attachments/assets/85d0c43e-e9a3-4bac-ad75-8320d0ee7828" />


ghostty: 
<img width="1508" height="661" alt="image" src="https://github.com/user-attachments/assets/2733b10e-6bd7-4d4b-9b84-73900ec486b0" />
2

Terminal:
<img width="1014" height="550" alt="image" src="https://github.com/user-attachments/assets/3bec5590-cfd8-4662-b615-24894afe89fb" />


## Related

<!-- Closes #123 -->
