### PR TITLE
feat(ui): render items as a collapsible directory tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/jroimartin/gocui v0.5.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 )
 
 require (
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 )

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,8 +17,14 @@ type App struct {
 	Items           []domain.Item
 	itemsByCategory map[domain.Kind][]domain.Item
 
+	// collapsed tracks which directory/file paths (see row.path) are
+	// collapsed in the content pane's tree. Absent key = expanded, so new
+	// paths default to expanded and collapse choices survive rescan/setItems
+	// without any seeding or reset logic.
+	collapsed map[string]bool
+
 	CategorySelected int
-	ItemSelected     int
+	RowSelected      int
 
 	Categories *scrollview.View
 	Content    *scrollview.View
@@ -30,7 +36,8 @@ type App struct {
 
 func New(svc *application.Service) (*App, error) {
 	a := &App{
-		Service: svc,
+		Service:   svc,
+		collapsed: make(map[string]bool),
 		Categories: scrollview.New(scrollview.Config{
 			BaseName:      "categories",
 			Title:         " [1] Categories ",
@@ -68,13 +75,25 @@ func (a *App) setItems(items []domain.Item) {
 		a.CategorySelected = len(categoryOrder) - 1
 	}
 
-	n := len(a.currentCategoryItems())
-	if a.ItemSelected >= n {
-		a.ItemSelected = n - 1
+	n := len(a.visibleRows())
+	if a.RowSelected >= n {
+		a.RowSelected = n - 1
 	}
-	if a.ItemSelected < 0 {
-		a.ItemSelected = 0
+	if a.RowSelected < 0 {
+		a.RowSelected = 0
 	}
+}
+
+func (a *App) visibleRows() []row {
+	return buildRows(a.currentCategoryItems(), a.collapsed)
+}
+
+func (a *App) selectedRow() (row, bool) {
+	rows := a.visibleRows()
+	if a.RowSelected < 0 || a.RowSelected >= len(rows) {
+		return row{}, false
+	}
+	return rows[a.RowSelected], true
 }
 
 func (a *App) currentCategory() domain.Kind {
@@ -86,9 +105,9 @@ func (a *App) currentCategoryItems() []domain.Item {
 }
 
 func (a *App) selectedItem() (domain.Item, bool) {
-	items := a.currentCategoryItems()
-	if a.ItemSelected < 0 || a.ItemSelected >= len(items) {
+	r, ok := a.selectedRow()
+	if !ok || r.kind != rowKindItem {
 		return domain.Item{}, false
 	}
-	return items[a.ItemSelected], true
+	return r.item, true
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +84,7 @@ func TestCategoryMoveUpDownClampToCategoryBounds(t *testing.T) {
 	}
 }
 
-func TestItemMoveUpDownClampToItemBounds(t *testing.T) {
+func TestRowMoveUpDownClampToRowBounds(t *testing.T) {
 	dir := t.TempDir()
 	mainGo := filepath.Join(dir, "main.go")
 	content := "// TODO: one\n// TODO: two\n// TODO: three\n"
@@ -92,25 +93,25 @@ func TestItemMoveUpDownClampToItemBounds(t *testing.T) {
 	}
 
 	app := newTestApp(t, dir)
-	items := app.currentCategoryItems()
-	if len(items) != 3 {
-		t.Fatalf("currentCategoryItems = %+v, want 3", items)
+	rows := app.visibleRows()
+	if len(rows) != 4 {
+		t.Fatalf("visibleRows = %+v, want 4 (1 file header + 3 items)", rows)
 	}
 
-	if err := app.itemMoveUp(nil, nil); err != nil {
-		t.Fatalf("itemMoveUp: %v", err)
+	if err := app.rowMoveUp(nil, nil); err != nil {
+		t.Fatalf("rowMoveUp: %v", err)
 	}
-	if app.ItemSelected != 0 {
-		t.Errorf("ItemSelected = %d after itemMoveUp at top, want clamped to 0", app.ItemSelected)
+	if app.RowSelected != 0 {
+		t.Errorf("RowSelected = %d after rowMoveUp at top, want clamped to 0", app.RowSelected)
 	}
 
 	for i := 0; i < 5; i++ {
-		if err := app.itemMoveDown(nil, nil); err != nil {
-			t.Fatalf("itemMoveDown: %v", err)
+		if err := app.rowMoveDown(nil, nil); err != nil {
+			t.Fatalf("rowMoveDown: %v", err)
 		}
 	}
-	if app.ItemSelected != len(items)-1 {
-		t.Errorf("ItemSelected = %d after moving past the end, want clamped to %d", app.ItemSelected, len(items)-1)
+	if app.RowSelected != len(rows)-1 {
+		t.Errorf("RowSelected = %d after moving past the end, want clamped to %d", app.RowSelected, len(rows)-1)
 	}
 }
 
@@ -122,17 +123,127 @@ func TestCategoryMoveResetsItemSelection(t *testing.T) {
 	}
 
 	app := newTestApp(t, dir)
-	if err := app.itemMoveDown(nil, nil); err != nil {
-		t.Fatalf("itemMoveDown: %v", err)
+	if err := app.rowMoveDown(nil, nil); err != nil {
+		t.Fatalf("rowMoveDown: %v", err)
 	}
-	if app.ItemSelected != 1 {
-		t.Fatalf("ItemSelected = %d before category change, want 1", app.ItemSelected)
+	if app.RowSelected != 1 {
+		t.Fatalf("RowSelected = %d before category change, want 1", app.RowSelected)
 	}
 
 	if err := app.categoryMoveDown(nil, nil); err != nil {
 		t.Fatalf("categoryMoveDown: %v", err)
 	}
-	if app.ItemSelected != 0 {
-		t.Errorf("ItemSelected = %d after categoryMoveDown, want reset to 0", app.ItemSelected)
+	if app.RowSelected != 0 {
+		t.Errorf("RowSelected = %d after categoryMoveDown, want reset to 0", app.RowSelected)
+	}
+}
+
+func TestCollapseSurvivesRescan(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "a.go"), []byte("// TODO: one\n"), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	app := newTestApp(t, dir)
+	app.collapsed["sub"] = true
+
+	before := len(app.visibleRows())
+	if err := app.rescan(nil, nil); err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	after := len(app.visibleRows())
+
+	if before != after {
+		t.Fatalf("visibleRows changed across rescan (%d -> %d), want collapse state preserved", before, after)
+	}
+	if !app.collapsed["sub"] {
+		t.Errorf("collapsed[\"sub\"] = false after rescan, want still collapsed")
+	}
+}
+
+func TestCollapseSurvivesCategorySwitch(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	content := "// TODO: one\n// FIXME: two\n"
+	if err := os.WriteFile(filepath.Join(subdir, "a.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	app := newTestApp(t, dir)
+	app.collapsed["sub"] = true
+
+	if err := app.categoryMoveDown(nil, nil); err != nil {
+		t.Fatalf("categoryMoveDown: %v", err)
+	}
+	if err := app.categoryMoveUp(nil, nil); err != nil {
+		t.Fatalf("categoryMoveUp: %v", err)
+	}
+
+	if !app.collapsed["sub"] {
+		t.Errorf("collapsed[\"sub\"] = false after switching category and back, want still collapsed")
+	}
+}
+
+func TestActivateSelectedRowDirTogglesCollapse(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "a.go"), []byte("// TODO: one\n"), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	app := newTestApp(t, dir)
+	rows := app.visibleRows()
+	if len(rows) == 0 || rows[0].kind != rowKindDir {
+		t.Fatalf("visibleRows[0] = %+v, want a dir row", rows)
+	}
+	app.RowSelected = 0
+
+	if err := app.activateSelectedRow(nil, nil); err != nil {
+		t.Fatalf("activateSelectedRow: %v", err)
+	}
+	if !app.collapsed[rows[0].path] {
+		t.Errorf("collapsed[%q] = false after activateSelectedRow on a dir row, want true", rows[0].path)
+	}
+	if app.pendingEdit != nil {
+		t.Errorf("pendingEdit = %+v after toggling a dir row, want nil", app.pendingEdit)
+	}
+}
+
+func TestActivateSelectedRowItemOpensEditor(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("// TODO: one\n"), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	app := newTestApp(t, dir)
+	rows := app.visibleRows()
+	itemIdx := -1
+	for i, r := range rows {
+		if r.kind == rowKindItem {
+			itemIdx = i
+			break
+		}
+	}
+	if itemIdx < 0 {
+		t.Fatalf("visibleRows = %+v, want at least one item row", rows)
+	}
+	app.RowSelected = itemIdx
+
+	err := app.activateSelectedRow(nil, nil)
+	if !errors.Is(err, errOpenEditor) {
+		t.Fatalf("activateSelectedRow on item row error = %v, want errOpenEditor", err)
+	}
+	if app.pendingEdit == nil {
+		t.Fatalf("pendingEdit = nil after activateSelectedRow on item row, want set")
 	}
 }

--- a/internal/ui/components/scrollview/internal.go
+++ b/internal/ui/components/scrollview/internal.go
@@ -59,7 +59,6 @@ func (v *View) renderWidth(contentView *gocui.View) int {
 	}
 
 	width, _ := contentView.Size()
-	width -= v.scrollbarWidth
 	if width < 1 {
 		return 1
 	}

--- a/internal/ui/components/scrollview/layout.go
+++ b/internal/ui/components/scrollview/layout.go
@@ -28,7 +28,7 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 
 	contentRight := x1 - 1
 	if !v.hideScrollbar {
-		contentRight = x1 - v.scrollbarWidth - 1
+		contentRight = x1 - v.scrollbarWidth
 	}
 
 	if contentLeft >= contentRight || contentTop >= contentBottom {
@@ -49,7 +49,7 @@ func (v *View) Layout(g *gocui.Gui, x0, y0, x1, y1 int) error {
 		return nil
 	}
 
-	scrollLeft := x1 - v.scrollbarWidth + 1
+	scrollLeft := contentRight
 	scrollTop := y0
 	scrollRight := x1
 	scrollBottom := y1

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -48,12 +48,13 @@ func (a *App) BindKeys(g *gocui.Gui) error {
 		key interface{}
 		fn  func(*gocui.Gui, *gocui.View) error
 	}{
-		{gocui.KeyArrowDown, a.itemMoveDown},
-		{'j', a.itemMoveDown},
-		{gocui.KeyArrowUp, a.itemMoveUp},
-		{'k', a.itemMoveUp},
-		{gocui.KeyEnter, a.openSelectedInEditor},
-		{'o', a.openSelectedInEditor},
+		{gocui.KeyArrowDown, a.rowMoveDown},
+		{'j', a.rowMoveDown},
+		{gocui.KeyArrowUp, a.rowMoveUp},
+		{'k', a.rowMoveUp},
+		{gocui.KeyEnter, a.activateSelectedRow},
+		{'o', a.activateSelectedRow},
+		{gocui.KeySpace, a.activateSelectedRow},
 	}
 	for _, viewname := range []string{a.Content.WrapperName(), a.Content.ContentViewName(), a.Content.ScrollViewName()} {
 		if err := g.SetKeybinding(viewname, gocui.MouseLeft, gocui.ModNone, a.focusItems); err != nil {
@@ -88,7 +89,7 @@ func (a *App) focusItems(g *gocui.Gui, v *gocui.View) error {
 func (a *App) categoryMoveDown(g *gocui.Gui, v *gocui.View) error {
 	if a.CategorySelected < len(categoryOrder)-1 {
 		a.CategorySelected++
-		a.ItemSelected = 0
+		a.RowSelected = 0
 	}
 	return nil
 }
@@ -96,22 +97,34 @@ func (a *App) categoryMoveDown(g *gocui.Gui, v *gocui.View) error {
 func (a *App) categoryMoveUp(g *gocui.Gui, v *gocui.View) error {
 	if a.CategorySelected > 0 {
 		a.CategorySelected--
-		a.ItemSelected = 0
+		a.RowSelected = 0
 	}
 	return nil
 }
 
-func (a *App) itemMoveDown(g *gocui.Gui, v *gocui.View) error {
-	if a.ItemSelected < len(a.currentCategoryItems())-1 {
-		a.ItemSelected++
+func (a *App) rowMoveDown(g *gocui.Gui, v *gocui.View) error {
+	if a.RowSelected < len(a.visibleRows())-1 {
+		a.RowSelected++
 	}
 	return nil
 }
 
-func (a *App) itemMoveUp(g *gocui.Gui, v *gocui.View) error {
-	if a.ItemSelected > 0 {
-		a.ItemSelected--
+func (a *App) rowMoveUp(g *gocui.Gui, v *gocui.View) error {
+	if a.RowSelected > 0 {
+		a.RowSelected--
 	}
+	return nil
+}
+
+func (a *App) activateSelectedRow(g *gocui.Gui, v *gocui.View) error {
+	r, ok := a.selectedRow()
+	if !ok {
+		return nil
+	}
+	if r.kind == rowKindItem {
+		return a.openSelectedInEditor(g, v)
+	}
+	a.collapsed[r.path] = !a.collapsed[r.path]
 	return nil
 }
 

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -5,11 +5,17 @@ import (
 	"strings"
 
 	"github.com/jroimartin/gocui"
+	"github.com/mattn/go-runewidth"
 
 	"github.com/issam-assiyadi/leftmark/domain"
 )
 
 const rowStyleReset = "\x1b[0m"
+
+// fileRowStyle marks a file row bold so it stands out from the directory
+// rows above it and the item rows nested under it, without assuming
+// anything about the terminal's color scheme.
+const fileRowStyle = "\x1b[1m"
 
 // selectedRowStyle marks a row as selected with bold + reverse video,
 // tinted with fgColor beforehand — the same accent frameColors gives
@@ -46,39 +52,36 @@ func (a *App) Render(g *gocui.Gui) error {
 		return err
 	}
 
-	items := a.currentCategoryItems()
+	rows := a.visibleRows()
 	if err := a.Content.SetTitle(g, fmt.Sprintf(" [2] Items - %s ", a.currentCategory())); err != nil {
 		return err
 	}
 
-	focus := a.ItemSelected
-	if len(items) == 0 {
+	focus := a.RowSelected
+	if len(rows) == 0 {
 		focus = -1
 	}
 
 	itemStyle := selectedRowStyle(a.Content.FocusFgColor(g))
 	return a.Content.Render(g, focus, func(v *gocui.View, contentWidth int) error {
-		if len(items) == 0 {
+		if len(rows) == 0 {
 			_, _ = fmt.Fprintln(v, "No items in this category")
 			return nil
 		}
-		for i, item := range items {
-			line := "  " + renderItemRow(item)
-			if i == a.ItemSelected {
-				if pad := contentWidth - len(line); pad > 0 {
-					line += strings.Repeat(" ", pad)
-				}
+		for i, r := range rows {
+			line := "  " + formatRow(r, contentWidth-2)
+			switch {
+			case i == a.RowSelected:
+				line = runewidth.FillRight(line, contentWidth)
 				_, _ = fmt.Fprintf(v, "%s%s%s\n", itemStyle, line, rowStyleReset)
-			} else {
+			case r.kind == rowKindFile:
+				_, _ = fmt.Fprintf(v, "%s%s%s\n", fileRowStyle, line, rowStyleReset)
+			default:
 				_, _ = fmt.Fprintln(v, line)
 			}
 		}
 		return nil
 	})
-}
-
-func renderItemRow(item domain.Item) string {
-	return fmt.Sprintf("%s:%d %s", item.File, item.Line, item.Text)
 }
 
 const categoryMetaRightPad = 1

--- a/internal/ui/tree.go
+++ b/internal/ui/tree.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+
+	"github.com/issam-assiyadi/leftmark/domain"
+)
+
+type rowKind int
+
+const (
+	rowKindDir rowKind = iota
+	rowKindFile
+	rowKindItem
+)
+
+// row is one visible line of the content pane's tree: a directory, a file,
+// or a marker item nested under a file. Its index in the []row slice
+// buildRows returns is exactly the line it renders to, since each row is
+// one Fprintln and domain.Item.Text can never contain a newline.
+type row struct {
+	kind     rowKind
+	label    string // dir/file: leaf name; unused for item rows
+	path     string // dir/file: full relative path, forward-slash-joined - collapsed map key
+	prefix   string // ancestor indent/branch glyphs, not including this row's own connector
+	isLast   bool   // true if this is the last child among its siblings
+	expanded bool   // dir/file rows only: true if not collapsed
+	hasKids  bool   // dir/file rows only: true if it has children to show
+	item     domain.Item
+}
+
+type dirNode struct {
+	subdirs map[string]*dirNode
+	files   map[string]*fileNode
+}
+
+type fileNode struct {
+	items []domain.Item
+}
+
+func newDirNode() *dirNode {
+	return &dirNode{subdirs: make(map[string]*dirNode), files: make(map[string]*fileNode)}
+}
+
+// buildRows groups items by directory (derived from Item.File) into a tree,
+// then flattens it into an ordered list of visible rows, skipping the
+// children of any path present (and true) in collapsed.
+func buildRows(items []domain.Item, collapsed map[string]bool) []row {
+	root := newDirNode()
+	for _, item := range items {
+		parts := strings.Split(filepath.ToSlash(item.File), "/")
+		dir := root
+		for _, part := range parts[:len(parts)-1] {
+			next, ok := dir.subdirs[part]
+			if !ok {
+				next = newDirNode()
+				dir.subdirs[part] = next
+			}
+			dir = next
+		}
+		fileName := parts[len(parts)-1]
+		f, ok := dir.files[fileName]
+		if !ok {
+			f = &fileNode{}
+			dir.files[fileName] = f
+		}
+		f.items = append(f.items, item)
+	}
+
+	var rows []row
+	walkDir(root, "", "", collapsed, &rows)
+	return rows
+}
+
+func walkDir(dir *dirNode, path, prefix string, collapsed map[string]bool, rows *[]row) {
+	subdirNames := sortedKeys(dir.subdirs)
+	fileNames := sortedKeys(dir.files)
+	total := len(subdirNames) + len(fileNames)
+	i := 0
+
+	for _, name := range subdirNames {
+		isLast := i == total-1
+		i++
+
+		label, node := compressChain(dir.subdirs[name], name)
+		childPath := joinPath(path, label)
+		expanded := !collapsed[childPath]
+		*rows = append(*rows, row{
+			kind:     rowKindDir,
+			label:    label,
+			path:     childPath,
+			prefix:   prefix,
+			isLast:   isLast,
+			expanded: expanded,
+			hasKids:  true,
+		})
+
+		if expanded {
+			walkDir(node, childPath, childPrefix(prefix, isLast), collapsed, rows)
+		}
+	}
+
+	for _, name := range fileNames {
+		isLast := i == total-1
+		i++
+
+		childPath := joinPath(path, name)
+		f := dir.files[name]
+		expanded := !collapsed[childPath]
+		*rows = append(*rows, row{
+			kind:     rowKindFile,
+			label:    name,
+			path:     childPath,
+			prefix:   prefix,
+			isLast:   isLast,
+			expanded: expanded,
+			hasKids:  len(f.items) > 0,
+		})
+
+		if expanded {
+			itemPrefix := childPrefix(prefix, isLast)
+			nItems := len(f.items)
+			for j, item := range f.items {
+				*rows = append(*rows, row{
+					kind:   rowKindItem,
+					prefix: itemPrefix,
+					isLast: j == nItems-1,
+					item:   item,
+				})
+			}
+		}
+	}
+}
+
+// compressChain collapses a chain of directories that each contain exactly
+// one subdirectory and no marked files into a single "a/b/c"-labeled row,
+// mirroring how editors like VS Code merge such chains in their file tree.
+// It stops as soon as a directory has any files or more/fewer than one
+// subdirectory, returning that directory as the node to recurse into next.
+func compressChain(dir *dirNode, label string) (string, *dirNode) {
+	for len(dir.subdirs) == 1 && len(dir.files) == 0 {
+		var childName string
+		var child *dirNode
+		for name, node := range dir.subdirs {
+			childName, child = name, node
+		}
+		label = label + "/" + childName
+		dir = child
+	}
+	return label, dir
+}
+
+func childPrefix(parentPrefix string, parentIsLast bool) string {
+	if parentIsLast {
+		return parentPrefix + "    "
+	}
+	return parentPrefix + "│   "
+}
+
+func joinPath(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "/" + name
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func connector(r row) string {
+	if r.isLast {
+		return "╰── "
+	}
+	return "├── "
+}
+
+func expandGlyph(r row) string {
+	if !r.hasKids {
+		return "  "
+	}
+	if r.expanded {
+		return "▾ "
+	}
+	return "▸ "
+}
+
+// formatRow renders r as a single display line, truncated to fit
+// contentWidth (measured in terminal columns, not bytes).
+func formatRow(r row, contentWidth int) string {
+	var text string
+	switch r.kind {
+	case rowKindDir:
+		text = r.prefix + connector(r) + expandGlyph(r) + r.label + "/"
+	case rowKindFile:
+		text = r.prefix + connector(r) + expandGlyph(r) + r.label
+	case rowKindItem:
+		text = r.prefix + connector(r) + fmt.Sprintf("%d %s", r.item.Line, sanitizeText(r.item.Text))
+	}
+
+	return runewidth.Truncate(text, contentWidth, "…")
+}
+
+func sanitizeText(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s)
+}

--- a/internal/ui/tree_test.go
+++ b/internal/ui/tree_test.go
@@ -1,0 +1,196 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+
+	"github.com/issam-assiyadi/leftmark/domain"
+)
+
+func TestBuildRowsMultiDir(t *testing.T) {
+	items := []domain.Item{
+		{Kind: domain.KindTODO, File: "b.go", Line: 1, Text: "root file"},
+		{Kind: domain.KindTODO, File: "zdir/a.go", Line: 1, Text: "in zdir"},
+		{Kind: domain.KindTODO, File: "adir/nested/a.go", Line: 1, Text: "deep"},
+		{Kind: domain.KindTODO, File: "adir/a.go", Line: 1, Text: "in adir"},
+	}
+
+	rows := buildRows(items, nil)
+
+	type summary struct {
+		kind  rowKind
+		label string
+	}
+	var gotRows []summary
+	for _, r := range rows {
+		if r.kind == rowKindItem {
+			continue
+		}
+		gotRows = append(gotRows, summary{r.kind, r.label})
+	}
+
+	want := []summary{
+		{rowKindDir, "adir"},
+		{rowKindDir, "nested"},
+		{rowKindFile, "a.go"}, // adir/nested/a.go
+		{rowKindFile, "a.go"}, // adir/a.go
+		{rowKindDir, "zdir"},
+		{rowKindFile, "a.go"}, // zdir/a.go
+		{rowKindFile, "b.go"},
+	}
+
+	if len(gotRows) != len(want) {
+		t.Fatalf("buildRows dir/file rows = %+v, want %+v", gotRows, want)
+	}
+	for i := range want {
+		if gotRows[i] != want[i] {
+			t.Errorf("row %d = %+v, want %+v", i, gotRows[i], want[i])
+		}
+	}
+}
+
+func TestBuildRowsCollapse(t *testing.T) {
+	items := []domain.Item{
+		{Kind: domain.KindTODO, File: "dir/a.go", Line: 1, Text: "one"},
+		{Kind: domain.KindTODO, File: "dir/a.go", Line: 2, Text: "two"},
+		{Kind: domain.KindTODO, File: "other.go", Line: 1, Text: "three"},
+	}
+
+	expanded := buildRows(items, map[string]bool{})
+	// dir, dir/a.go, item one, item two, other.go, other.go's item = 6 rows
+	if len(expanded) != 6 {
+		t.Fatalf("expanded rows = %d, want 6: %+v", len(expanded), expanded)
+	}
+
+	collapsedDir := buildRows(items, map[string]bool{"dir": true})
+	// dir, other.go, other.go's item = 3 rows (dir/a.go + its items hidden)
+	if len(collapsedDir) != 3 {
+		t.Fatalf("collapsed-dir rows = %d, want 3: %+v", len(collapsedDir), collapsedDir)
+	}
+
+	collapsedFile := buildRows(items, map[string]bool{"dir/a.go": true})
+	// dir, dir/a.go, other.go, other.go's item = 4 rows (dir/a.go's items hidden)
+	if len(collapsedFile) != 4 {
+		t.Fatalf("collapsed-file rows = %d, want 4: %+v", len(collapsedFile), collapsedFile)
+	}
+}
+
+func TestBuildRowsCompressesSingleChildChains(t *testing.T) {
+	items := []domain.Item{
+		{Kind: domain.KindTODO, File: "folder-1/folder-2/sub-folder-1/test.go", Line: 1, Text: "deep"},
+	}
+
+	rows := buildRows(items, nil)
+	if len(rows) != 3 {
+		t.Fatalf("buildRows = %+v, want 3 (1 merged dir + 1 file + 1 item)", rows)
+	}
+
+	dirRow := rows[0]
+	if dirRow.kind != rowKindDir || dirRow.label != "folder-1/folder-2/sub-folder-1" {
+		t.Errorf("rows[0] = %+v, want a dir row labeled \"folder-1/folder-2/sub-folder-1\"", dirRow)
+	}
+	if dirRow.path != "folder-1/folder-2/sub-folder-1" {
+		t.Errorf("rows[0].path = %q, want %q", dirRow.path, "folder-1/folder-2/sub-folder-1")
+	}
+
+	fileRow := rows[1]
+	if fileRow.kind != rowKindFile || fileRow.label != "test.go" {
+		t.Errorf("rows[1] = %+v, want a file row labeled \"test.go\"", fileRow)
+	}
+
+	collapsed := buildRows(items, map[string]bool{"folder-1/folder-2/sub-folder-1": true})
+	if len(collapsed) != 1 {
+		t.Fatalf("collapsing the merged chain = %+v, want just the 1 dir row", collapsed)
+	}
+}
+
+func TestBuildRowsStopsCompressionAtBranchOrFile(t *testing.T) {
+	items := []domain.Item{
+		{Kind: domain.KindTODO, File: "a/b/one.go", Line: 1, Text: "one"},
+		{Kind: domain.KindTODO, File: "a/b/c/two.go", Line: 1, Text: "two"},
+		{Kind: domain.KindTODO, File: "x/y/three.go", Line: 1, Text: "three"},
+	}
+
+	rows := buildRows(items, nil)
+
+	var labels []string
+	for _, r := range rows {
+		if r.kind == rowKindDir {
+			labels = append(labels, r.label)
+		}
+	}
+
+	// "a" has no files of its own and exactly one subdirectory ("b"), so it
+	// merges into "a/b". "a/b" itself has a file (one.go) alongside its
+	// subdir "c", so the chain stops there - "c" gets its own row instead
+	// of merging further. "x/y" has no files at either level, so it merges
+	// fully into one row.
+	want := []string{"a/b", "c", "x/y"}
+	if len(labels) != len(want) {
+		t.Fatalf("dir labels = %v, want %v", labels, want)
+	}
+	for i := range want {
+		if labels[i] != want[i] {
+			t.Errorf("dir label %d = %q, want %q (all: %v)", i, labels[i], want[i], labels)
+		}
+	}
+}
+
+func TestFormatRowWidth(t *testing.T) {
+	tests := []struct {
+		name string
+		r    row
+		w    int
+	}{
+		{
+			name: "deep prefix with box-drawing glyphs",
+			r: row{
+				kind:    rowKindFile,
+				label:   "file.go",
+				prefix:  "│   │   ",
+				isLast:  true,
+				hasKids: true,
+			},
+			w: 12,
+		},
+		{
+			name: "item row with wide CJK text",
+			r: row{
+				kind:   rowKindItem,
+				prefix: "    ",
+				isLast: true,
+				item:   domain.Item{Line: 42, Text: "修复这个问题 fix this"},
+			},
+			w: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatRow(tt.r, tt.w)
+			if w := runewidth.StringWidth(got); w > tt.w {
+				t.Errorf("formatRow(%+v, %d) = %q, display width %d > %d", tt.r, tt.w, got, w, tt.w)
+			}
+		})
+	}
+}
+
+func TestFormatRowWidthWouldFailNaiveLenCheck(t *testing.T) {
+	r := row{
+		kind:    rowKindDir,
+		label:   "dir",
+		prefix:  "│   │   │   ",
+		isLast:  false,
+		hasKids: true,
+	}
+	w := 20
+
+	got := formatRow(r, w)
+	if len(got) <= w {
+		t.Fatalf("expected byte length to exceed display width for this glyph-heavy row, got byte len %d for %q", len(got), got)
+	}
+	if runewidth.StringWidth(got) > w {
+		t.Fatalf("formatRow(%+v, %d) = %q, display width %d > %d", r, w, got, runewidth.StringWidth(got), w)
+	}
+}


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo


https://github.com/user-attachments/assets/f3ae0467-4fe1-48c3-b296-39cc25d70bdd



## Related

Closes #49 
