### PR TITLE
feat(tui): add keybinding to toggle categories pane

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -20,6 +20,8 @@ type App struct {
 	CategorySelected int
 	RowSelected      int
 
+	categoriesVisible bool
+
 	Categories *scrollview.View
 	Content    *scrollview.View
 	Preview    *modal.Modal
@@ -55,6 +57,7 @@ func New(svc *application.Service) (*App, error) {
 		}),
 	}
 	a.focused = a.Categories.WrapperName()
+	a.categoriesVisible = true
 
 	items, err := svc.Scan()
 	if err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"time"
+
 	"github.com/issam-assiyadi/leftmark/application"
 	"github.com/issam-assiyadi/leftmark/domain"
 	"github.com/issam-assiyadi/leftmark/internal/ui/components/modal"
@@ -21,6 +23,7 @@ type App struct {
 	RowSelected      int
 
 	categoriesVisible bool
+	leaderArmedAt     time.Time
 
 	Categories *scrollview.View
 	Content    *scrollview.View

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -266,6 +266,9 @@ func TestActivateSelectedRowItemOpensPreview(t *testing.T) {
 func TestToggleCategoriesHidesAndShows(t *testing.T) {
 	app := newTestApp(t, t.TempDir())
 
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -273,6 +276,9 @@ func TestToggleCategoriesHidesAndShows(t *testing.T) {
 		t.Fatalf("categoriesVisible = true after one toggle, want false")
 	}
 
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -287,6 +293,9 @@ func TestToggleCategoriesMovesFocusOffCategories(t *testing.T) {
 		t.Fatalf("focused = %q at startup, want the categories wrapper view", app.focused)
 	}
 
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -299,6 +308,9 @@ func TestToggleCategoriesPreservesFocusOnContent(t *testing.T) {
 	app := newTestApp(t, t.TempDir())
 	app.focused = app.Content.WrapperName()
 
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -313,6 +325,9 @@ func TestToggleCategoriesNoOpWhenModalOpen(t *testing.T) {
 		t.Fatalf("openHelp: %v", err)
 	}
 
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -323,6 +338,9 @@ func TestToggleCategoriesNoOpWhenModalOpen(t *testing.T) {
 
 func TestFocusCategoriesNoOpWhenHidden(t *testing.T) {
 	app := newTestApp(t, t.TempDir())
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
 	if err := app.toggleCategories(nil, nil); err != nil {
 		t.Fatalf("toggleCategories: %v", err)
 	}
@@ -333,5 +351,31 @@ func TestFocusCategoriesNoOpWhenHidden(t *testing.T) {
 	}
 	if app.focused != app.Content.WrapperName() {
 		t.Errorf("focused = %q after focusCategories while hidden, want unchanged content wrapper view", app.focused)
+	}
+}
+
+func TestToggleCategoriesRequiresLeaderArmed(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if !app.categoriesVisible {
+		t.Errorf("categoriesVisible = false after toggleCategories without arming the leader, want unchanged true")
+	}
+}
+
+func TestToggleCategoriesLeaderExpires(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+	if err := app.armLeader(nil, nil); err != nil {
+		t.Fatalf("armLeader: %v", err)
+	}
+	app.leaderArmedAt = app.leaderArmedAt.Add(-2 * leaderTimeout)
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if !app.categoriesVisible {
+		t.Errorf("categoriesVisible = false after the leader window expired, want unchanged true")
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -262,3 +262,76 @@ func TestActivateSelectedRowItemOpensPreview(t *testing.T) {
 		t.Errorf("focused = %q after closePreview, want restored to %q", app.focused, previousFocused)
 	}
 }
+
+func TestToggleCategoriesHidesAndShows(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if app.categoriesVisible {
+		t.Fatalf("categoriesVisible = true after one toggle, want false")
+	}
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if !app.categoriesVisible {
+		t.Fatalf("categoriesVisible = false after two toggles, want true")
+	}
+}
+
+func TestToggleCategoriesMovesFocusOffCategories(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+	if app.focused != app.Categories.WrapperName() {
+		t.Fatalf("focused = %q at startup, want the categories wrapper view", app.focused)
+	}
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if app.focused != app.Content.WrapperName() {
+		t.Errorf("focused = %q after hiding categories, want the content wrapper view", app.focused)
+	}
+}
+
+func TestToggleCategoriesPreservesFocusOnContent(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+	app.focused = app.Content.WrapperName()
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if app.focused != app.Content.WrapperName() {
+		t.Errorf("focused = %q after hiding categories, want unchanged content wrapper view", app.focused)
+	}
+}
+
+func TestToggleCategoriesNoOpWhenModalOpen(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+	if err := app.openHelp(nil, nil); err != nil {
+		t.Fatalf("openHelp: %v", err)
+	}
+
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	if !app.categoriesVisible {
+		t.Errorf("categoriesVisible = false after toggling with a modal open, want unchanged true")
+	}
+}
+
+func TestFocusCategoriesNoOpWhenHidden(t *testing.T) {
+	app := newTestApp(t, t.TempDir())
+	if err := app.toggleCategories(nil, nil); err != nil {
+		t.Fatalf("toggleCategories: %v", err)
+	}
+	app.focused = app.Content.WrapperName()
+
+	if err := app.focusCategories(nil, nil); err != nil {
+		t.Fatalf("focusCategories: %v", err)
+	}
+	if app.focused != app.Content.WrapperName() {
+		t.Errorf("focused = %q after focusCategories while hidden, want unchanged content wrapper view", app.focused)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -61,6 +61,8 @@ func formatKey(key interface{}) string {
 	switch k := key.(type) {
 	case rune:
 		return string(k)
+	case leaderChord:
+		return "<leader>" + string(rune(k))
 	case gocui.Key:
 		if label, ok := keyLabels[k]; ok {
 			return label

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -19,6 +19,7 @@ func (a *App) globalKeyBindings() []appKeyBinding {
 		{'r', a.rescan, "Rescan"},
 		{'1', a.focusCategories, "Focus categories pane"},
 		{'2', a.focusItems, "Focus items pane"},
+		{'c', a.toggleCategories, "Toggle categories pane"},
 		{'?', a.openHelp, "Show keybinding help"},
 	}
 }
@@ -93,12 +94,42 @@ func (a *App) quit(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (a *App) focusCategories(g *gocui.Gui, v *gocui.View) error {
-	if a.modalOpen() {
+	if a.modalOpen() || !a.categoriesVisible {
 		return nil
 	}
 	a.focused = a.Categories.WrapperName()
 	_, err := g.SetCurrentView(a.focused)
 	return err
+}
+
+// toggleCategories shows or hides the Categories pane so Content can
+// expand to fill the freed width. modalOpen() guards against leaving a
+// modal's previousFocused pointing at a view we're about to delete. The
+// synchronous a.layout(g) call is required: run.go's manager renders
+// before it lays out, so without this the re-shown pane would draw one
+// empty frame before its views exist.
+func (a *App) toggleCategories(g *gocui.Gui, v *gocui.View) error {
+	if a.modalOpen() {
+		return nil
+	}
+	a.categoriesVisible = !a.categoriesVisible
+	if !a.categoriesVisible {
+		a.Categories.Delete(g)
+		if a.focused == a.Categories.WrapperName() {
+			a.focused = a.Content.WrapperName()
+		}
+	}
+
+	if g == nil {
+		return nil
+	}
+	if err := a.layout(g); err != nil {
+		return err
+	}
+	if _, err := g.SetCurrentView(a.focused); err != nil {
+		log.Println("categories: unable to focus view:", err)
+	}
+	return nil
 }
 
 func (a *App) focusItems(g *gocui.Gui, v *gocui.View) error {

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"log"
+	"time"
 
 	"github.com/awesome-gocui/gocui"
 )
@@ -12,6 +13,14 @@ type appKeyBinding struct {
 	desc string
 }
 
+// leaderChord marks a global keybinding's second key in a <leader>-prefixed
+// chord (Space, matching Vim's default leader, then the rune below). It
+// exists only for display: formatKey renders it as "<leader>x", while
+// BindKeys registers the underlying rune with gocui like any other key.
+type leaderChord rune
+
+const leaderTimeout = time.Second
+
 func (a *App) globalKeyBindings() []appKeyBinding {
 	return []appKeyBinding{
 		{gocui.KeyCtrlC, a.quit, "Quit"},
@@ -19,7 +28,7 @@ func (a *App) globalKeyBindings() []appKeyBinding {
 		{'r', a.rescan, "Rescan"},
 		{'1', a.focusCategories, "Focus categories pane"},
 		{'2', a.focusItems, "Focus items pane"},
-		{'c', a.toggleCategories, "Toggle categories pane"},
+		{leaderChord('e'), a.toggleCategories, "Toggle categories pane"},
 		{'?', a.openHelp, "Show keybinding help"},
 	}
 }
@@ -41,13 +50,19 @@ func (a *App) itemKeyBindings() []appKeyBinding {
 		{'k', a.rowMoveUp, "Move up"},
 		{gocui.KeyEnter, a.activateSelectedRow, "Open item / toggle folder"},
 		{'o', a.activateSelectedRow, "Open item / toggle folder"},
-		{gocui.KeySpace, a.activateSelectedRow, "Open item / toggle folder"},
 	}
 }
 
 func (a *App) BindKeys(g *gocui.Gui) error {
+	if err := g.SetKeybinding("", gocui.KeySpace, gocui.ModNone, a.armLeader); err != nil {
+		return err
+	}
 	for _, b := range a.globalKeyBindings() {
-		if err := g.SetKeybinding("", b.key, gocui.ModNone, b.fn); err != nil {
+		key := b.key
+		if lc, ok := key.(leaderChord); ok {
+			key = rune(lc)
+		}
+		if err := g.SetKeybinding("", key, gocui.ModNone, b.fn); err != nil {
 			return err
 		}
 	}
@@ -102,6 +117,24 @@ func (a *App) focusCategories(g *gocui.Gui, v *gocui.View) error {
 	return err
 }
 
+// armLeader starts the <leader> chord's timeout window on Space, Vim's
+// default leader key. It's registered directly rather than through
+// globalKeyBindings so it stays out of the help modal - by itself it does
+// nothing a user would want listed as a binding.
+func (a *App) armLeader(g *gocui.Gui, v *gocui.View) error {
+	a.leaderArmedAt = time.Now()
+	return nil
+}
+
+// consumeLeader reports whether Space was pressed within leaderTimeout of
+// now, and clears the pending state either way so a chord can't be
+// completed twice or after the window closes.
+func (a *App) consumeLeader() bool {
+	armed := !a.leaderArmedAt.IsZero() && time.Since(a.leaderArmedAt) <= leaderTimeout
+	a.leaderArmedAt = time.Time{}
+	return armed
+}
+
 // toggleCategories shows or hides the Categories pane so Content can
 // expand to fill the freed width. modalOpen() guards against leaving a
 // modal's previousFocused pointing at a view we're about to delete. The
@@ -109,7 +142,7 @@ func (a *App) focusCategories(g *gocui.Gui, v *gocui.View) error {
 // before it lays out, so without this the re-shown pane would draw one
 // empty frame before its views exist.
 func (a *App) toggleCategories(g *gocui.Gui, v *gocui.View) error {
-	if a.modalOpen() {
+	if !a.consumeLeader() || a.modalOpen() {
 		return nil
 	}
 	a.categoriesVisible = !a.categoriesVisible

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -14,21 +14,23 @@ func (a *App) layout(g *gocui.Gui) error {
 		return nil
 	}
 
-	sidebarWidth := max(maxX/4, 20)
-	if sidebarWidth > maxX-2 {
-		sidebarWidth = maxX - 2
-	}
-	if sidebarWidth < 2 {
-		sidebarWidth = 2
-	}
-
 	paneBottom := maxY - 2
 
-	if err := a.Categories.Layout(g, 0, 0, sidebarWidth-1, paneBottom); err != nil {
-		return err
+	contentLeft := 0
+	if a.categoriesVisible {
+		sidebarWidth := max(maxX/4, 20)
+		if sidebarWidth > maxX-2 {
+			sidebarWidth = maxX - 2
+		}
+		if sidebarWidth < 2 {
+			sidebarWidth = 2
+		}
+		if err := a.Categories.Layout(g, 0, 0, sidebarWidth-1, paneBottom); err != nil {
+			return err
+		}
+		contentLeft = sidebarWidth
 	}
 
-	contentLeft := sidebarWidth
 	contentTop := 0
 	contentRight := maxX - 1
 	contentBottom := paneBottom

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -44,21 +44,23 @@ func selectedRowStyle(fgColor gocui.Attribute) string {
 }
 
 func (a *App) Render(g *gocui.Gui) error {
-	categoryStyle := selectedRowStyle(a.Categories.FocusFgColor(g))
-	if err := a.Categories.Render(g, a.CategorySelected, func(v *gocui.View, contentWidth int) error {
-		rowWidth := contentWidth - len("  ")
-		for i, kind := range categoryOrder {
-			count := len(a.itemsByCategory[kind])
-			row := "  " + formatCategoryRow(rowWidth, kind, count)
-			if i == a.CategorySelected {
-				_, _ = fmt.Fprintf(v, "%s%s%s\n", categoryStyle, row, rowStyleReset)
-			} else {
-				_, _ = fmt.Fprintln(v, row)
+	if a.categoriesVisible {
+		categoryStyle := selectedRowStyle(a.Categories.FocusFgColor(g))
+		if err := a.Categories.Render(g, a.CategorySelected, func(v *gocui.View, contentWidth int) error {
+			rowWidth := contentWidth - len("  ")
+			for i, kind := range categoryOrder {
+				count := len(a.itemsByCategory[kind])
+				row := "  " + formatCategoryRow(rowWidth, kind, count)
+				if i == a.CategorySelected {
+					_, _ = fmt.Fprintf(v, "%s%s%s\n", categoryStyle, row, rowStyleReset)
+				} else {
+					_, _ = fmt.Fprintln(v, row)
+				}
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	rows := a.visibleRows()

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -10,7 +10,7 @@ const statusBarViewName = "statusbar"
 
 const statusBarStyle = "\x1b[38;5;244m"
 
-const statusBarText = "↑/↓ | k/j Move   Enter/Space Open   r Rescan   c Categories   ? Help   q Quit"
+const statusBarText = "↑/↓ | k/j Move   Enter/o Open   r Rescan   <leader>e Categories   ? Help   q Quit"
 
 func (a *App) layoutStatusBar(g *gocui.Gui, maxX, maxY int) error {
 	v, err := g.SetView(statusBarViewName, -1, maxY-2, maxX, maxY, 0)

--- a/internal/ui/statusbar.go
+++ b/internal/ui/statusbar.go
@@ -10,7 +10,7 @@ const statusBarViewName = "statusbar"
 
 const statusBarStyle = "\x1b[38;5;244m"
 
-const statusBarText = "↑/↓ | k/j Move   Enter/Space Open   r Rescan   ? Help   q Quit"
+const statusBarText = "↑/↓ | k/j Move   Enter/Space Open   r Rescan   c Categories   ? Help   q Quit"
 
 func (a *App) layoutStatusBar(g *gocui.Gui, maxX, maxY int) error {
 	v, err := g.SetView(statusBarViewName, -1, maxY-2, maxX, maxY, 0)


### PR DESCRIPTION
Lets the items pane expand to full width when the category is already picked and the sidebar is just taking up space.

## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo


https://github.com/user-attachments/assets/e7353a25-afcf-4c90-b09e-412069893617



## Related

Closes #39 
