### PR TITLE
feat(cli): filter scan output by category

### DIFF
--- a/internal/cliadapter/commands.go
+++ b/internal/cliadapter/commands.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/issam-assiyadi/leftmark"
 	"github.com/issam-assiyadi/leftmark/adapter/config"
@@ -14,6 +15,33 @@ import (
 	"github.com/issam-assiyadi/leftmark/application"
 	"github.com/issam-assiyadi/leftmark/domain"
 )
+
+var scanCategories = []domain.Kind{domain.KindTODO, domain.KindFIXME, domain.KindNOTE, domain.KindQUESTION}
+
+// parseCategory resolves a --category flag value to a domain.Kind,
+// case-insensitively. An empty input means "no filter" and is always valid.
+func parseCategory(s string) (kind domain.Kind, ok bool) {
+	if s == "" {
+		return "", true
+	}
+	upper := domain.Kind(strings.ToUpper(s))
+	for _, k := range scanCategories {
+		if k == upper {
+			return k, true
+		}
+	}
+	return "", false
+}
+
+func filterByKind(items []domain.Item, kind domain.Kind) []domain.Item {
+	var filtered []domain.Item
+	for _, item := range items {
+		if item.Kind == kind {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
 
 func newService(root string) (*application.Service, error) {
 	explicitRoot := root != ""
@@ -68,7 +96,14 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	root := fs.String("root", "", "repo root (default: current directory)")
 	jsonOut := fs.Bool("json", false, "print JSON")
+	category := fs.String("category", "", "filter by category: TODO, FIXME, NOTE, or QUESTION")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	kind, ok := parseCategory(*category)
+	if !ok {
+		printf(stderr, "unknown category %q, want one of TODO, FIXME, NOTE, QUESTION\n", *category)
 		return 2
 	}
 
@@ -82,6 +117,9 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		printf(stderr, "%v\n", err)
 		return 1
+	}
+	if kind != "" {
+		items = filterByKind(items, kind)
 	}
 	return printItems(items, *jsonOut, stdout)
 }

--- a/internal/cliadapter/dispatch_test.go
+++ b/internal/cliadapter/dispatch_test.go
@@ -55,6 +55,37 @@ func TestScanOverCLI(t *testing.T) {
 	}
 }
 
+func TestScanFiltersByCategory(t *testing.T) {
+	dir := t.TempDir()
+	mainGo := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainGo, []byte("// TODO: a\n// FIXME: b\n"), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+
+	stdout, stderr, code := run(t, "scan", "--root", dir, "--json", "--category", "fixme")
+	if code != 0 {
+		t.Fatalf("scan exit=%d stderr=%s", code, stderr)
+	}
+	var scanned []item
+	if err := json.Unmarshal([]byte(stdout), &scanned); err != nil {
+		t.Fatalf("unmarshal scan output %q: %v", stdout, err)
+	}
+	if len(scanned) != 1 || scanned[0].Kind != "FIXME" {
+		t.Fatalf("scan output = %+v, want one FIXME item", scanned)
+	}
+}
+
+func TestScanRejectsUnknownCategory(t *testing.T) {
+	dir := t.TempDir()
+	_, stderr, code := run(t, "scan", "--root", dir, "--category", "bogus")
+	if code != 2 {
+		t.Fatalf("scan exit=%d, want 2", code)
+	}
+	if stderr == "" {
+		t.Fatalf("expected an error message on stderr for an unknown category")
+	}
+}
+
 func TestReportOverCLI(t *testing.T) {
 	dir := t.TempDir()
 	mainGo := filepath.Join(dir, "main.go")


### PR DESCRIPTION
Adds --category to leftmark scan, matching case-insensitively against TODO, FIXME, NOTE, and QUESTION.

## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo

<!-- Terminal recording or screenshots for TUI-visible changes.
     CI can't verify these visually. N/A if not applicable. -->

## Related

<!-- Closes #123 -->
