### PR TITLE
feat: add version flag, LICENSE, and release tooling for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,12 @@ jobs:
       - name: Run tests
         run: make test
 
-      # --skip=homebrew until issam-assiyadi/homebrew-tap exists and
-      # HOMEBREW_TAP_TOKEN is set; drop it once the tap is ready.
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --skip=homebrew
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+      # --skip=homebrew until issam-assiyadi/homebrew-tap exists and
+      # HOMEBREW_TAP_TOKEN is set; drop it once the tap is ready.
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+version: 2
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: leftmark
+    binary: leftmark
+    main: ./tui/leftmark
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/issam-assiyadi/leftmark/internal/version.version={{.Version}}
+
+archives:
+  - id: leftmark
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  use: github
+
+release:
+  github:
+    owner: issam-assiyadi
+    name: leftmark
+  draft: true
+
+homebrew_casks:
+  - name: leftmark
+    repository:
+      owner: issam-assiyadi
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/issam-assiyadi/leftmark"
+    description: "A scanner for the TODOs, FIXMEs, notes, and questions you already leave in your codebase."
+    license: "MIT"
+    binaries: [leftmark]
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/leftmark"]
+          end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Issam Assiyadi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ In short:
 
 Coming soon.
 
+## Installation
+
+### Go install
+
+```bash
+go install github.com/issam-assiyadi/leftmark/tui/leftmark@latest
+```
+
+### Homebrew
+
+```bash
+brew tap issam-assiyadi/homebrew-tap
+brew install leftmark
+```
+
+### Prebuilt binaries
+
+Download the archive for your OS/arch from the [Releases page](https://github.com/issam-assiyadi/leftmark/releases),
+extract it, and place the `leftmark` binary on your `PATH`.
+
 ## How it works
 
 1. **Scan.** `leftmark` walks your project (respecting `.gitignore`) looking for `TODO`, `FIXME`, `NOTE`, and `QUESTION` comments, in any language. Every scan is fresh: nothing is written back to your source and nothing persists between runs.

--- a/internal/cliadapter/dispatch.go
+++ b/internal/cliadapter/dispatch.go
@@ -7,6 +7,8 @@ package cliadapter
 import (
 	"fmt"
 	"io"
+
+	"github.com/issam-assiyadi/leftmark/internal/version"
 )
 
 var subcommands = map[string]func(args []string, stdout, stderr io.Writer) int{
@@ -24,11 +26,31 @@ func Dispatch(args []string, stdout, stderr io.Writer) (handled bool, exitCode i
 		return false, 0
 	}
 
+	switch args[0] {
+	case "--version", "-v", "version":
+		printf(stdout, "leftmark %s\n", version.Version())
+		return true, 0
+	case "--help", "-h", "help":
+		printUsage(stdout)
+		return true, 0
+	}
+
 	run, ok := subcommands[args[0]]
 	if !ok {
 		return false, 0
 	}
 	return true, run(args[1:], stdout, stderr)
+}
+
+func printUsage(w io.Writer) {
+	printf(w, "leftmark - a scanner for TODOs, FIXMEs, notes, and questions left in code comments\n\n")
+	printf(w, "Usage:\n")
+	printf(w, "  leftmark              launch the TUI\n")
+	printf(w, "  leftmark scan         scan for items and print them\n")
+	printf(w, "  leftmark report       print a summary count of items by kind\n")
+	printf(w, "  leftmark hook         manage git hooks\n")
+	printf(w, "  leftmark --version    print the version\n")
+	printf(w, "  leftmark --help       print this help\n")
 }
 
 func printf(w io.Writer, format string, args ...interface{}) {

--- a/internal/cliadapter/dispatch_test.go
+++ b/internal/cliadapter/dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/issam-assiyadi/leftmark/internal/cliadapter"
@@ -32,6 +33,30 @@ func TestUnknownArgsFallThroughToTUI(t *testing.T) {
 	handled, _ := cliadapter.Dispatch(nil, &out, &errBuf)
 	if handled {
 		t.Errorf("Dispatch(nil) should not be handled, so the caller falls back to the TUI")
+	}
+}
+
+func TestVersionFlag(t *testing.T) {
+	for _, arg := range []string{"--version", "-v", "version"} {
+		stdout, _, code := run(t, arg)
+		if code != 0 {
+			t.Errorf("Dispatch(%q) exit=%d, want 0", arg, code)
+		}
+		if !strings.HasPrefix(stdout, "leftmark ") {
+			t.Errorf("Dispatch(%q) stdout=%q, want prefix %q", arg, stdout, "leftmark ")
+		}
+	}
+}
+
+func TestHelpFlag(t *testing.T) {
+	for _, arg := range []string{"--help", "-h", "help"} {
+		stdout, _, code := run(t, arg)
+		if code != 0 {
+			t.Errorf("Dispatch(%q) exit=%d, want 0", arg, code)
+		}
+		if !strings.HasPrefix(stdout, "leftmark ") {
+			t.Errorf("Dispatch(%q) stdout=%q, want prefix %q", arg, stdout, "leftmark ")
+		}
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,39 @@
+// Package version resolves the leftmark version string at runtime across
+// two build paths: GoReleaser builds inject it via -ldflags, while a plain
+// `go install pkg@vX.Y.Z` never passes ldflags but has the requested
+// version stamped into the binary's build info automatically.
+package version
+
+import (
+	"runtime/debug"
+	"unicode"
+)
+
+// version is set via -ldflags "-X .../internal/version.version=X.Y.Z" by
+// GoReleaser, using its {{.Version}} template value, which has no leading
+// "v". It stays empty for a plain `go build` or local `go install`.
+var version string
+
+// Version returns the ldflags-injected value if set, otherwise the module
+// version Go's build stamps into the binary for `go install pkg@vX.Y.Z`,
+// otherwise "dev". The result always carries a "v" prefix when it's a
+// version number, so it reads the same regardless of which build path
+// produced the binary.
+func Version() string {
+	if version != "" {
+		return withVPrefix(version)
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			return info.Main.Version
+		}
+	}
+	return "dev"
+}
+
+func withVPrefix(v string) string {
+	if v == "" || v[0] == 'v' || !unicode.IsDigit(rune(v[0])) {
+		return v
+	}
+	return "v" + v
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,18 @@
+package version
+
+import "testing"
+
+func TestWithVPrefix(t *testing.T) {
+	cases := map[string]string{
+		"0.1.0":                  "v0.1.0",
+		"v0.1.0":                 "v0.1.0",
+		"0.0.0-SNAPSHOT-13c6520": "v0.0.0-SNAPSHOT-13c6520",
+		"dev":                    "dev",
+		"":                       "",
+	}
+	for in, want := range cases {
+		if got := withVPrefix(in); got != want {
+			t.Errorf("withVPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Changes

<!-- What changed and why. One bullet per meaningful change. -->

## Architecture check

<!-- Tick each box, or explain in Insights why it doesn't apply.
     Rule: domain -> nothing; application -> domain only (new capabilities
     are a port in application/ports.go, implemented by an adapter);
     adapter/* -> domain/application only; internal/ui and internal/cliadapter
     depend on application/domain, not adapter/* directly (except the existing
     githook case in cliadapter). wire.go is the only place that wires
     adapters + application together. -->

- [ ] `domain/` added no import of `application`, `adapter/*`, or `internal/*`
- [ ] `application/` added no import of `adapter/*` or `internal/*` — any new capability is a port in `application/ports.go`, implemented by an adapter
- [ ] `adapter/*` added no import of `internal/ui` or `internal/cliadapter`
- [ ] `internal/ui` / `internal/cliadapter` added no new direct `adapter/*` import outside the existing `githook` case
- [ ] N/A — this PR doesn't touch `domain/`, `application/`, or `adapter/*`

## Insights

<!-- Tradeoffs, risks, or context a reviewer needs.
     Flag any change to marker grammar — the `TODO`/`FIXME`/`NOTE`/`QUESTION`
     vocabulary or how comments are detected. -->

## Demo

<!-- Terminal recording or screenshots for TUI-visible changes.
     CI can't verify these visually. N/A if not applicable. -->

## Related

<!-- Closes #123 -->
